### PR TITLE
minor style adjustment for mobile devices

### DIFF
--- a/.stylelintrc
+++ b/.stylelintrc
@@ -8,6 +8,6 @@
       ]
     }],
     "block-no-empty": null,
-    "unit-whitelist": ["em", "rem", "s"]
+    "unit-whitelist": ["em", "rem", "s", "vw", "vh"]
   }
 }

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -49,11 +49,14 @@ j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
               alt="Warga Bantu Warga"
               height="291"
               width="650"
-              style={{ maxWidth: 650, height: "auto", width: "40rem" }}
+              style={{ maxWidth: "100%", height: "auto" }}
             />
           </h1>
         </header>
-        <article dangerouslySetInnerHTML={{ __html: props.html }}></article>
+        <article
+          className="p-3"
+          dangerouslySetInnerHTML={{ __html: props.html }}
+        ></article>
       </main>
     </>
   );

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -4,12 +4,8 @@
 @tailwind variants;
 
 body {
-  max-width: 40rem;
+  max-width: min(40rem, 100vw);
   margin: 0 auto;
-}
-
-table {
-  width: 40rem;
 }
 
 img {


### PR DESCRIPTION
First iteration of #68, not really resolve as this is only minor style adjustment

## Description

Feedback from my wife, when visiting through mobile feels cramped.

My solution was to:
 1. Set the width to 40 rem on larger screen devices, but take full `100vw` on mobile device.
 2. Make necessary changes to both article and header image so header image still take 100% of space, while the article have small padding as it contains mostly text

## Result

Before/After
<img src="https://user-images.githubusercontent.com/1614415/125810737-2e6778f0-9d86-4738-8f80-ec084ab8d6e5.png" width="300" /><img src="https://user-images.githubusercontent.com/1614415/125810798-45cecea2-f173-4799-955d-5704829bf96a.png" width="300" />

