### PR TITLE
Remove nth child check for faster performance

### DIFF
--- a/etc/fetchers/fetch-sheets.js
+++ b/etc/fetchers/fetch-sheets.js
@@ -25,9 +25,7 @@ module.exports.fetchSheets = async function fetchSheets() {
     .map((_, li) => {
       const sheetId = $(li).attr("id").replace("sheet-button-", "");
       const sheetName = $(li).text();
-      const sheetColumns = $(
-        `[id='${sheetId}'] > div > table > tbody > tr:nth-child(1)`,
-      )
+      const sheetColumns = $(`#${sheetId} tbody > tr:nth-child(1)`)
         .find("td")
         .map((colIndex, td) => {
           colMap[colIndex] = $(td).text();
@@ -38,10 +36,11 @@ module.exports.fetchSheets = async function fetchSheets() {
         })
         .toArray()
         .filter((col) => col.name.trim().length !== 0);
-      const sheetRows = $(
-        `[id='${sheetId}'] > div > table > tbody > tr:not(:nth-child(1))`,
-      )
-        .map((__, tr) => {
+      const sheetRows = $(`#${sheetId} tbody > tr`)
+        .map((rowIndex, tr) => {
+          if (rowIndex === 0) {
+            return [];
+          }
           return [
             $(tr)
               .find("td")


### PR DESCRIPTION
Closes <!-- mention the issue that you're trying to close with this PR -->

## Description

The query selector that involves `nth-child` check is very expensive, so we remove it to improve the performance. Based on the data at https://github.com/kawalcovid19/wargabantuwarga.com/discussions/139, it could reduce the duration for sheet fetching from 39.98s to 25.41s.

## Current Tasks

<!-- List the tasks that you're planning to do in this PR.
This is to indicate how much you have been progressing before this PR is ready for review -->

- [ ] 
- [ ] 
- [ ] 
