### PR TITLE
remove `min-h-screen` class on error pages

### DIFF
--- a/components/layout/page-content.tsx
+++ b/components/layout/page-content.tsx
@@ -2,7 +2,7 @@ import * as React from "react";
 
 export const PageContent: React.FC = ({ children }) => {
   return (
-    <div className="px-4 pt-4 pb-12">
+    <div className="flex-1 px-4 pt-4 pb-12">
       <div className="max-w-xl mx-auto">{children}</div>
     </div>
   );

--- a/components/layout/page.tsx
+++ b/components/layout/page.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
 
 export const Page: React.FC = ({ children }) => {
-  return <section className="flex-1 pt-20">{children}</section>;
+  return <section className="flex flex-col flex-1 pt-20">{children}</section>;
 };

--- a/pages/404.tsx
+++ b/pages/404.tsx
@@ -9,7 +9,7 @@ export default function FourOhFour() {
       <PageContent>
         <div className="px-4 py-16 sm:px-6 sm:py-24 md:grid md:place-items-center lg:px-8">
           <div className="py-16 sm:py-24 max-w-max mx-auto">
-            <main className="sm:flex">
+            <div className="sm:flex">
               <p className="text-4xl font-extrabold text-blue-600 sm:text-5xl">
                 404
               </p>
@@ -31,7 +31,7 @@ export default function FourOhFour() {
                   </Link>
                 </div>
               </div>
-            </main>
+            </div>
           </div>
         </div>
       </PageContent>

--- a/pages/404.tsx
+++ b/pages/404.tsx
@@ -7,8 +7,8 @@ export default function FourOhFour() {
   return (
     <Page>
       <PageContent>
-        <div className="min-h-screen px-4 py-16 sm:px-6 sm:py-24 md:grid md:place-items-center lg:px-8">
-          <div className="max-w-max mx-auto">
+        <div className="px-4 py-16 sm:px-6 sm:py-24 md:grid md:place-items-center lg:px-8">
+          <div className="py-16 sm:py-24 max-w-max mx-auto">
             <main className="sm:flex">
               <p className="text-4xl font-extrabold text-blue-600 sm:text-5xl">
                 404

--- a/pages/_error.tsx
+++ b/pages/_error.tsx
@@ -8,7 +8,7 @@ export default function FallbackError() {
     <Page>
       <PageContent>
         <div className="pt-16 pb-12 flex flex-col">
-          <main className="flex-grow flex flex-col justify-center max-w-7xl w-full mx-auto px-4 sm:px-6 lg:px-8">
+          <div className="flex-grow flex flex-col justify-center max-w-7xl w-full mx-auto px-4 sm:px-6 lg:px-8">
             <div className="py-16">
               <div className="text-center">
                 <h1 className="mt-2 text-4xl font-extrabold text-gray-900 tracking-tight sm:text-5xl">
@@ -28,7 +28,7 @@ export default function FallbackError() {
                 </div>
               </div>
             </div>
-          </main>
+          </div>
         </div>
       </PageContent>
     </Page>

--- a/pages/_error.tsx
+++ b/pages/_error.tsx
@@ -7,7 +7,7 @@ export default function FallbackError() {
   return (
     <Page>
       <PageContent>
-        <div className="min-h-screen pt-16 pb-12 flex flex-col">
+        <div className="pt-16 pb-12 flex flex-col">
           <main className="flex-grow flex flex-col justify-center max-w-7xl w-full mx-auto px-4 sm:px-6 lg:px-8">
             <div className="py-16">
               <div className="text-center">
@@ -21,6 +21,7 @@ export default function FallbackError() {
                   <button
                     className="text-base font-medium text-blue-600"
                     onClick={refreshPage}
+                    type="button"
                   >
                     Muat ulang halaman
                   </button>


### PR DESCRIPTION
## Description

a height of 100vh doesn't work well on child containers, causing a rogue scrollbar to appear.

![image](https://user-images.githubusercontent.com/5663877/126074992-038eda1d-6837-415c-8f58-c399cfc2fe9c.png)

This fixes it.
