### PR TITLE
add dropdown filter for faq page

### DIFF
--- a/components/select-dropdown.tsx
+++ b/components/select-dropdown.tsx
@@ -1,0 +1,43 @@
+export function SelectDropdown({
+  selectedCategory,
+  setSelectedCategory,
+  listOptions,
+}: {
+  selectedCategory: string;
+  setSelectedCategory: (value: string) => void;
+  listOptions: unknown[];
+}) {
+  return (
+    <div className="flex flex-col pb-4">
+      <label
+        className="block text-sm font-medium text-gray-700"
+        htmlFor="kategori-pertanyaan"
+        id="listbox-label"
+      >
+        Atau cari berdasarkan kategori pertanyaan:
+      </label>
+      <div className="flex items-center mt-1">
+        <select
+          className="focus:ring-indigo-500 focus:border-indigo-500 block w-full px-2 py-2 sm:text-sm border-gray-300 border-2 rounded-md"
+          id="kategori-pertanyaan"
+          name="kategori-pertanyaan"
+          onChange={(e) => {
+            setSelectedCategory(e.target.value);
+          }}
+          value={selectedCategory}
+        >
+          <option value="">Semua</option>
+          {Object.keys(listOptions as Record<string, unknown>).map(
+            (category: string) => {
+              return (
+                <option key={category} value={category}>
+                  {category}
+                </option>
+              );
+            },
+          )}
+        </select>
+      </div>
+    </div>
+  );
+}

--- a/pages/faq.tsx
+++ b/pages/faq.tsx
@@ -1,10 +1,11 @@
-import { useMemo } from "react";
+import { useMemo, useState } from "react";
 
 import { BackButton } from "../components/layout/back-button";
 import { Page } from "../components/layout/page";
 import { PageContent } from "../components/layout/page-content";
 import { PageHeader } from "../components/layout/page-header";
 import { SearchForm } from "../components/search-form";
+import { SelectDropdown } from "../components/select-dropdown";
 import faqSheets, { FaqData } from "../lib/faq-databases";
 import { useSearch } from "../lib/hooks/use-search";
 
@@ -32,14 +33,39 @@ export default function Faqs(props: FaqsProps) {
     "pertanyaan",
     "jawaban",
   ]);
+  const [selectedCategory, setSelectedCategory] = useState("");
+
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+  const selectedQuestions = filteredQuestions.filter((f) => {
+    // eslint-disable-next-line no-negated-condition
+    if (selectedCategory !== "") {
+      return f.kategori_pertanyaan == selectedCategory;
+    } else {
+      return filteredQuestions;
+    }
+  });
 
   // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
   const listFaqs = useMemo(() => {
-    return groupBy<FaqData | unknown, string>(
-      filteredQuestions,
-      "kategori_pertanyaan",
-    );
-  }, [filteredQuestions]);
+    // eslint-disable-next-line no-negated-condition
+    if (selectedCategory !== "") {
+      return groupBy<FaqData | unknown, string>(
+        selectedQuestions,
+        "kategori_pertanyaan",
+      );
+    } else {
+      return groupBy<FaqData | unknown, string>(
+        filteredQuestions,
+        "kategori_pertanyaan",
+      );
+    }
+  }, [selectedQuestions]);
+
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+  const listOptions = groupBy<FaqData | unknown, string>(
+    filteredQuestions,
+    "kategori_pertanyaan",
+  );
 
   return (
     <Page>
@@ -58,6 +84,11 @@ export default function Faqs(props: FaqsProps) {
         <SearchForm
           itemName="pertanyaan"
           onSubmitKeywords={handleSubmitKeywords}
+        />
+        <SelectDropdown
+          listOptions={listOptions}
+          selectedCategory={selectedCategory}
+          setSelectedCategory={setSelectedCategory}
         />
         <div className="space-y-4">
           {Object.keys(listFaqs as Record<string, unknown>).map(

--- a/pages/faq.tsx
+++ b/pages/faq.tsx
@@ -63,7 +63,7 @@ export default function Faqs(props: FaqsProps) {
 
   // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
   const listOptions = groupBy<FaqData | unknown, string>(
-    filteredQuestions,
+    faqSheets,
     "kategori_pertanyaan",
   );
 


### PR DESCRIPTION
Closes <!-- mention the issue that you're trying to close with this PR -->
I want to close #96 

## Description

<!-- Describe your implementation plan and approach -->
Since both inputs (search form and this dropdown) are filtering the same list `listFaqs` it's kind of tricky on both relations to filter the data. So I did two steps filter, the first one from the existing search form results `filteredQuestions`. 
Then I added an array filter on `filteredQuestions` to get a list of `selectedQuestions` based on selected value from `dropdown/select` element. 
For the memo hook, I'm using the `selectedQuestions` list as dependencies.

So the options list on the select dropdown also depends on the search terms input by the user. Next, I think we need an empty state when one or both options don't show any results.
Please kindly check the gif image below to see the changes.

![wbw dropdown](https://user-images.githubusercontent.com/3627108/126075792-60d09b8c-cda7-4a2b-a501-826fffc289c7.gif)

## Current Tasks

<!-- List the tasks that you're planning to do in this PR.
This is to indicate how much you have been progressing before this PR is ready for review -->

- [ ] 
- [ ] 
- [ ] 
