### PR TITLE
minor fixes to some page header titles + back button

### DIFF
--- a/components/layout/back-button.tsx
+++ b/components/layout/back-button.tsx
@@ -5,7 +5,6 @@ import Link, { LinkProps } from "next/link";
 
 type BackButtonProps = LinkProps;
 
-// TODO: Need to replace this with navbar-wide back button.
 export function BackButton(props: BackButtonProps) {
   return (
     <nav aria-label="Back" className="sm:hidden">
@@ -15,7 +14,7 @@ export function BackButton(props: BackButtonProps) {
             aria-hidden="true"
             className="flex-shrink-0 -ml-1 mr-1 h-5 w-5 text-gray-400"
           />
-          Back
+          Kembali
         </a>
       </Link>
     </nav>

--- a/pages/provinces/[provinceSlug]/index.tsx
+++ b/pages/provinces/[provinceSlug]/index.tsx
@@ -68,7 +68,7 @@ export default function ProvincePage(props: ProvinceProps) {
               current: true,
             },
           ]}
-          title={`Database for ${provinceName}`}
+          title={provinceName}
         />
         <PageContent>
           <SearchForm


### PR DESCRIPTION
## Description

Rename province slug page title:

![image](https://user-images.githubusercontent.com/5663877/126200274-13cb0026-af65-4a15-8221-23231e5820d5.png)

Fix copywriting on Back button (mobile only)

![image](https://user-images.githubusercontent.com/5663877/126200327-42dfc1a1-3ea5-4733-bae1-823c64a25032.png)
