### PR TITLE
add `package-lock.json` to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,9 @@
 /.pnp
 .pnp.js
 
+# npm lockfile (we use yarn)
+package-lock.json
+
 # testing
 /coverage
 
@@ -36,6 +39,7 @@ yarn-error.log*
 # ESLint
 .eslintcache
 
+# IntelliJ
 .idea/
 
 # Local Netlify folder


### PR DESCRIPTION
## Description

Some new contributors keep using `npm` even though the project itself uses `yarn`. This PR add `package-lock.json` to the gitignore file so that people won't accidentally commit npm's lockfile to the project.

In the future, we should explicitly mention in the README that **we use yarn, not npm**.
