### PR TITLE
add empty state on provinces + contact list

### DIFF
--- a/components/contact-list.tsx
+++ b/components/contact-list.tsx
@@ -3,7 +3,12 @@ import { anchorTransformer } from "../lib/htmr-transformers";
 import { Contact } from "../lib/provinces";
 import { isNotEmpty, stripTags } from "../lib/string-utils";
 
-import { BadgeCheckIcon as BadgeCheckIconUnverified } from "@heroicons/react/outline";
+import { EmptyState } from "./ui/empty-state";
+
+import {
+  BadgeCheckIcon as BadgeCheckIconUnverified,
+  ExclamationCircleIcon,
+} from "@heroicons/react/outline";
 import {
   BadgeCheckIcon,
   LocationMarkerIcon,
@@ -23,91 +28,105 @@ export function ContactList(props: ContactListProps) {
     a: anchorTransformer,
   };
 
-  return (
-    <div className="bg-white shadow overflow-hidden sm:rounded-md">
-      <ul className="divide-y divide-gray-200">
-        {props.data.map((contact, index) => (
-          <li key={index}>
-            <div className="px-4 py-4 sm:px-6 relative hover:bg-gray-50">
-              <div className="flex items-center justify-between">
-                <Link href={`/provinces/${props.provinceSlug}/${contact.slug}`}>
-                  <a className="text-sm font-semibold text-blue-600 truncate block helper-link-cover">
-                    {isNotEmpty(contact.penyedia)
-                      ? contact.penyedia
-                      : contact.keterangan}
-                  </a>
-                </Link>
-                <div className="ml-2 flex-shrink-0 flex">
-                  <p className="px-2 inline-flex text-xs leading-5 font-semibold rounded-full bg-yellow-100 text-yellow-800">
-                    {contact.kebutuhan}
-                  </p>
-                </div>
-              </div>
-              <div className="mt-2 sm:flex sm:justify-between">
-                <p className="text-sm font-medium text-gray-600 truncate">
-                  {contact.keterangan}
-                </p>
-                {isNotEmpty(contact.terakhir_update) ? (
-                  <div className="mt-2 mb-3 flex items-center text-xs text-gray-500 sm:my-0">
-                    <BadgeCheckIcon
-                      aria-hidden="true"
-                      className="flex-shrink-0 h-4 w-4 sm:order-2 text-green-400"
-                    />
-                    <p className="ml-2 mr-1">
-                      Terverifikasi{" "}
-                      {contact.terakhir_update && (
-                        <time dateTime={contact.terakhir_update}>
-                          {contact.terakhir_update}
-                        </time>
-                      )}
+  if (props.data.length > 0) {
+    return (
+      <div className="bg-white shadow overflow-hidden sm:rounded-md">
+        <ul className="divide-y divide-gray-200">
+          {props.data.map((contact, index) => (
+            <li key={index}>
+              <div className="px-4 py-4 sm:px-6 relative hover:bg-gray-50">
+                <div className="flex items-center justify-between">
+                  <Link
+                    href={`/provinces/${props.provinceSlug}/${contact.slug}`}
+                  >
+                    <a className="text-sm font-semibold text-blue-600 truncate block helper-link-cover">
+                      {isNotEmpty(contact.penyedia)
+                        ? contact.penyedia
+                        : contact.keterangan}
+                    </a>
+                  </Link>
+                  <div className="ml-2 flex-shrink-0 flex">
+                    <p className="px-2 inline-flex text-xs leading-5 font-semibold rounded-full bg-yellow-100 text-yellow-800">
+                      {contact.kebutuhan}
                     </p>
                   </div>
-                ) : (
-                  <div className="mt-2 mb-3 flex items-center text-xs text-gray-400 sm:my-0">
-                    <BadgeCheckIconUnverified
-                      aria-hidden="true"
-                      className="flex-shrink-0 h-4 w-4 sm:order-2 text-gray-400"
-                    />
-                    <p className="ml-2 mr-1">Belum terverifkasi</p>
+                </div>
+                <div className="mt-2 sm:flex sm:justify-between">
+                  <p className="text-sm font-medium text-gray-600 truncate">
+                    {contact.keterangan}
+                  </p>
+                  {isNotEmpty(contact.terakhir_update) ? (
+                    <div className="mt-2 mb-3 flex items-center text-xs text-gray-500 sm:my-0">
+                      <BadgeCheckIcon
+                        aria-hidden="true"
+                        className="flex-shrink-0 h-4 w-4 sm:order-2 text-green-400"
+                      />
+                      <p className="ml-2 mr-1">
+                        Terverifikasi{" "}
+                        {contact.terakhir_update && (
+                          <time dateTime={contact.terakhir_update}>
+                            {contact.terakhir_update}
+                          </time>
+                        )}
+                      </p>
+                    </div>
+                  ) : (
+                    <div className="mt-2 mb-3 flex items-center text-xs text-gray-400 sm:my-0">
+                      <BadgeCheckIconUnverified
+                        aria-hidden="true"
+                        className="flex-shrink-0 h-4 w-4 sm:order-2 text-gray-400"
+                      />
+                      <p className="ml-2 mr-1">Belum terverifkasi</p>
+                    </div>
+                  )}
+                </div>
+                {isNotEmpty(contact.kontak) && (
+                  <div className="mt-2 flex justify-between w-full">
+                    <p className="flex items-center text-sm text-gray-500">
+                      <PhoneIcon
+                        aria-hidden="true"
+                        className="flex-shrink-0 mr-2 h-4 w-4 text-gray-400"
+                      />
+                      {htmr(contact.kontak as string, {
+                        transform: htmrTransform,
+                      })}
+                    </p>
+                    {typeof contact.kontak == "string" && (
+                      <CopyButton text={stripTags(contact.kontak)} />
+                    )}
+                  </div>
+                )}
+                {isNotEmpty(contact.alamat) && (
+                  <div className="mt-2 flex justify-between w-full">
+                    <p className="mt-2 flex items-start text-sm text-gray-500 sm:mt-0">
+                      <LocationMarkerIcon
+                        aria-hidden="true"
+                        className="flex-shrink-0 mr-2 h-4 w-4 text-gray-400"
+                      />
+                      {htmr(contact.alamat as string, {
+                        transform: htmrTransform,
+                      })}
+                    </p>
+                    {typeof contact.alamat == "string" && (
+                      <CopyButton text={stripTags(contact.alamat)} />
+                    )}
                   </div>
                 )}
               </div>
-              {isNotEmpty(contact.kontak) && (
-                <div className="mt-2 flex justify-between w-full">
-                  <p className="flex items-center text-sm text-gray-500">
-                    <PhoneIcon
-                      aria-hidden="true"
-                      className="flex-shrink-0 mr-2 h-4 w-4 text-gray-400"
-                    />
-                    {htmr(contact.kontak as string, {
-                      transform: htmrTransform,
-                    })}
-                  </p>
-                  {typeof contact.kontak == "string" && (
-                    <CopyButton text={stripTags(contact.kontak)} />
-                  )}
-                </div>
-              )}
-              {isNotEmpty(contact.alamat) && (
-                <div className="mt-2 flex justify-between w-full">
-                  <p className="mt-2 flex items-start text-sm text-gray-500 sm:mt-0">
-                    <LocationMarkerIcon
-                      aria-hidden="true"
-                      className="flex-shrink-0 mr-2 h-4 w-4 text-gray-400"
-                    />
-                    {htmr(contact.alamat as string, {
-                      transform: htmrTransform,
-                    })}
-                  </p>
-                  {typeof contact.alamat == "string" && (
-                    <CopyButton text={stripTags(contact.alamat)} />
-                  )}
-                </div>
-              )}
-            </div>
-          </li>
-        ))}
-      </ul>
+            </li>
+          ))}
+        </ul>
+      </div>
+    );
+  }
+
+  return (
+    <div className="px-4 py-12">
+      <EmptyState
+        description="Silakan gunakan kata kunci pencarian lainnya."
+        icon={ExclamationCircleIcon}
+        title="Fasilitas tidak ditemukan"
+      />
     </div>
   );
 }

--- a/components/province-list.tsx
+++ b/components/province-list.tsx
@@ -1,3 +1,6 @@
+import { EmptyState } from "./ui/empty-state";
+
+import { ExclamationCircleIcon } from "@heroicons/react/outline";
 import Link from "next/link";
 
 export type ProvinceListItem = {
@@ -12,28 +15,40 @@ type ProvinceListProps = {
 };
 
 export function ProvinceList(props: ProvinceListProps) {
+  if (props.data.length > 0) {
+    return (
+      <ul className="mt-3 grid grid-cols-1 gap-5 sm:gap-6 lg:grid-cols-2">
+        {props.data.map((province) => (
+          <li
+            key={province.name}
+            className="col-span-1 flex shadow-sm rounded-md"
+          >
+            <div className="bg-blue-500 flex-shrink-0 flex items-center justify-center w-16 text-white text-sm font-medium rounded-l-md">
+              {province.initials}
+            </div>
+            <Link href={`/provinces/${province.slug}`}>
+              <a className="flex-1 flex items-center justify-between border-t border-r border-b border-gray-200 bg-white rounded-r-md truncate">
+                <div className="flex-1 px-4 py-2 text-sm truncate">
+                  <span className="text-gray-900 font-semibold hover:text-gray-600">
+                    {province.name}
+                  </span>
+                  <p className="text-gray-500">{province.count} Entri</p>
+                </div>
+              </a>
+            </Link>
+          </li>
+        ))}
+      </ul>
+    );
+  }
+
   return (
-    <ul className="mt-3 grid grid-cols-1 gap-5 sm:gap-6 lg:grid-cols-2">
-      {props.data.map((province) => (
-        <li
-          key={province.name}
-          className="col-span-1 flex shadow-sm rounded-md"
-        >
-          <div className="bg-blue-500 flex-shrink-0 flex items-center justify-center w-16 text-white text-sm font-medium rounded-l-md">
-            {province.initials}
-          </div>
-          <Link href={`/provinces/${province.slug}`}>
-            <a className="flex-1 flex items-center justify-between border-t border-r border-b border-gray-200 bg-white rounded-r-md truncate">
-              <div className="flex-1 px-4 py-2 text-sm truncate">
-                <span className="text-gray-900 font-semibold hover:text-gray-600">
-                  {province.name}
-                </span>
-                <p className="text-gray-500">{province.count} Entri</p>
-              </div>
-            </a>
-          </Link>
-        </li>
-      ))}
-    </ul>
+    <div className="px-4 py-12">
+      <EmptyState
+        description="Silakan gunakan kata kunci pencarian lainnya."
+        icon={ExclamationCircleIcon}
+        title="Provinsi tidak ditemukan"
+      />
+    </div>
   );
 }

--- a/components/ui/empty-state.tsx
+++ b/components/ui/empty-state.tsx
@@ -1,0 +1,30 @@
+import * as React from "react";
+
+interface EmptyStateProps {
+  title: string;
+  description?: string;
+  actions?: React.ReactNode;
+  icon?: React.ComponentType<React.SVGProps<SVGSVGElement>>;
+}
+
+export function EmptyState({
+  title,
+  description,
+  actions,
+  icon,
+}: EmptyStateProps) {
+  return (
+    <div className="text-center">
+      {icon &&
+        React.createElement(icon, {
+          "aria-hidden": true,
+          className: "mx-auto h-12 w-12 text-gray-400",
+        })}
+      <h3 className="mt-2 text-sm font-semibold text-gray-900">{title}</h3>
+      {description && (
+        <p className="mt-1 text-sm text-gray-500">{description}</p>
+      )}
+      {actions && <div className="mt-6">{actions}</div>}
+    </div>
+  );
+}


### PR DESCRIPTION
Closes #210. Closes #216.

## Description

Add an empty state component and use it in the `ProvincesList` and `ContactList` when data is empty.

![image](https://user-images.githubusercontent.com/5663877/126313302-c355f18e-d47e-4dfc-8248-c42a71c401f1.png)

![image](https://user-images.githubusercontent.com/5663877/126313057-7157c9d6-2dd3-4af6-bab1-8586e5ab1688.png)

## Tasks

- [x] Provinces page
- [x] Contacts page

