### PR TITLE
Absolute imports and module path alias

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -12,7 +12,15 @@
   "rules": {
     "@babel/new-cap": "off",
     "@typescript-eslint/no-explicit-any": "warn",
-    "import/extensions": ["warn", "never", { "css": "ignorePackages" }],
+    "import/extensions": [
+      "warn",
+      "never",
+      {
+        "css": "ignorePackages",
+        "json": "ignorePackages",
+        "md": "ignorePackages"
+      }
+    ],
     "import/newline-after-import": "warn",
     "import/no-extraneous-dependencies": "warn",
     "import/order": "off",

--- a/components/contact-details.tsx
+++ b/components/contact-details.tsx
@@ -1,7 +1,8 @@
-import { CopyButton } from "@components/copy-button";
-import { anchorTransformer } from "@lib/htmr-transformers";
-import { Contact } from "@lib/provinces";
-import { isNotEmpty, stripTags } from "@lib/string-utils";
+import { CopyButton } from "~/components/copy-button";
+import { anchorTransformer } from "~/lib/htmr-transformers";
+import { Contact } from "~/lib/provinces";
+import { isNotEmpty, stripTags } from "~/lib/string-utils";
+
 import htmr from "htmr";
 import { HtmrOptions } from "htmr/src/types";
 

--- a/components/contact-details.tsx
+++ b/components/contact-details.tsx
@@ -1,8 +1,7 @@
-import { CopyButton } from "../components/copy-button";
-import { anchorTransformer } from "../lib/htmr-transformers";
-import { Contact } from "../lib/provinces";
-import { isNotEmpty, stripTags } from "../lib/string-utils";
-
+import { CopyButton } from "@components/copy-button";
+import { anchorTransformer } from "@lib/htmr-transformers";
+import { Contact } from "@lib/provinces";
+import { isNotEmpty, stripTags } from "@lib/string-utils";
 import htmr from "htmr";
 import { HtmrOptions } from "htmr/src/types";
 

--- a/components/contact-list.tsx
+++ b/components/contact-list.tsx
@@ -1,10 +1,6 @@
-import { CopyButton } from "../components/copy-button";
-import { anchorTransformer } from "../lib/htmr-transformers";
-import { Contact } from "../lib/provinces";
-import { isNotEmpty, stripTags } from "../lib/string-utils";
-
 import { EmptyState } from "./ui/empty-state";
 
+import { CopyButton } from "@components/copy-button";
 import {
   BadgeCheckIcon as BadgeCheckIconUnverified,
   ExclamationCircleIcon,
@@ -14,6 +10,9 @@ import {
   LocationMarkerIcon,
   PhoneIcon,
 } from "@heroicons/react/solid";
+import { anchorTransformer } from "@lib/htmr-transformers";
+import { Contact } from "@lib/provinces";
+import { isNotEmpty, stripTags } from "@lib/string-utils";
 import htmr from "htmr";
 import { HtmrOptions } from "htmr/src/types";
 import Link from "next/link";

--- a/components/contact-list.tsx
+++ b/components/contact-list.tsx
@@ -1,6 +1,9 @@
-import { EmptyState } from "./ui/empty-state";
+import { CopyButton } from "~/components/copy-button";
+import { EmptyState } from "~/components/ui/empty-state";
+import { anchorTransformer } from "~/lib/htmr-transformers";
+import { Contact } from "~/lib/provinces";
+import { isNotEmpty, stripTags } from "~/lib/string-utils";
 
-import { CopyButton } from "@components/copy-button";
 import {
   BadgeCheckIcon as BadgeCheckIconUnverified,
   ExclamationCircleIcon,
@@ -10,9 +13,6 @@ import {
   LocationMarkerIcon,
   PhoneIcon,
 } from "@heroicons/react/solid";
-import { anchorTransformer } from "@lib/htmr-transformers";
-import { Contact } from "@lib/provinces";
-import { isNotEmpty, stripTags } from "@lib/string-utils";
 import htmr from "htmr";
 import { HtmrOptions } from "htmr/src/types";
 import Link from "next/link";

--- a/components/layout/global-header.tsx
+++ b/components/layout/global-header.tsx
@@ -1,4 +1,5 @@
-import WBWLogo from "@components/ui/wbw-logo";
+import WBWLogo from "~/components/ui/wbw-logo";
+
 import Link from "next/link";
 
 export function GlobalHeader() {

--- a/components/layout/global-header.tsx
+++ b/components/layout/global-header.tsx
@@ -1,5 +1,4 @@
-import WBWLogo from "../ui/wbw-logo";
-
+import WBWLogo from "@components/ui/wbw-logo";
 import Link from "next/link";
 
 export function GlobalHeader() {

--- a/components/layout/navigation.tsx
+++ b/components/layout/navigation.tsx
@@ -1,7 +1,6 @@
 import * as React from "react";
 
-import WhatsAppLogo from "../ui/whatsapp-logo";
-
+import WhatsAppLogo from "@components/ui/whatsapp-logo";
 import {
   HomeIcon,
   QuestionMarkCircleIcon,

--- a/components/layout/navigation.tsx
+++ b/components/layout/navigation.tsx
@@ -1,6 +1,7 @@
 import * as React from "react";
 
-import WhatsAppLogo from "@components/ui/whatsapp-logo";
+import WhatsAppLogo from "~/components/ui/whatsapp-logo";
+
 import {
   HomeIcon,
   QuestionMarkCircleIcon,

--- a/components/layout/page-header.tsx
+++ b/components/layout/page-header.tsx
@@ -1,7 +1,7 @@
 import * as React from "react";
 
-import { makeBreadcrumbJsonLd } from "../../lib/jsonld-generator";
-import { Breadcrumb, BreadcrumbItem } from "../ui/breadcrumb";
+import { makeBreadcrumbJsonLd } from "~/lib/jsonld-generator";
+import { Breadcrumb, BreadcrumbItem } from "~/components/ui/breadcrumb";
 
 import Head from "next/head";
 

--- a/components/report-button.tsx
+++ b/components/report-button.tsx
@@ -1,5 +1,5 @@
-import { Contact } from "../lib/provinces";
-import { stripTags } from "../lib/string-utils";
+import { Contact } from "~/lib/provinces";
+import { stripTags } from "~/lib/string-utils";
 
 import { SecondaryButton } from "./ui/button";
 

--- a/components/script.tsx
+++ b/components/script.tsx
@@ -4,7 +4,7 @@
 
 import { ScriptHTMLAttributes, useEffect } from "react";
 
-import { requestIdleCallback } from "@lib/request-idle-callback";
+import { requestIdleCallback } from "~/lib/request-idle-callback";
 
 const loadScript = (props: ScriptHTMLAttributes<HTMLScriptElement>): void => {
   const { dangerouslySetInnerHTML } = props;

--- a/components/script.tsx
+++ b/components/script.tsx
@@ -4,7 +4,7 @@
 
 import { ScriptHTMLAttributes, useEffect } from "react";
 
-import { requestIdleCallback } from "../lib/request-idle-callback";
+import { requestIdleCallback } from "@lib/request-idle-callback";
 
 const loadScript = (props: ScriptHTMLAttributes<HTMLScriptElement>): void => {
   const { dangerouslySetInnerHTML } = props;

--- a/components/search-form.tsx
+++ b/components/search-form.tsx
@@ -10,8 +10,8 @@ import React, {
   useState,
 } from "react";
 
-import { PrimaryButton, SecondaryButton } from "./ui/button";
-import { Select } from "./ui/select";
+import { PrimaryButton, SecondaryButton } from "~/components/ui/button";
+import { Select } from "~/components/ui/select";
 
 import { debounce } from "ts-debounce";
 

--- a/lib/faq-databases.ts
+++ b/lib/faq-databases.ts
@@ -1,4 +1,4 @@
-import faqSheets from "../data/wbw-faq-sheets.json";
+import faqSheets from "~/data/wbw-faq-sheets.json";
 
 export type Databases = FaqData[];
 

--- a/lib/jsonld-generator.ts
+++ b/lib/jsonld-generator.ts
@@ -1,5 +1,5 @@
-import { BreadcrumbItem } from "../components/ui/breadcrumb";
-import { PUBLIC_PATH } from "../constants";
+import { BreadcrumbItem } from "~/components/ui/breadcrumb";
+import { PUBLIC_PATH } from "~/constants";
 
 const HOME_STRUCTURE = {
   "@type": "ListItem",

--- a/lib/provinces.ts
+++ b/lib/provinces.ts
@@ -1,4 +1,4 @@
-import provinces from "../data/wbw-sheets.json";
+import provinces from "~/data/wbw-sheets.json";
 
 import { getSlug } from "./string-utils";
 

--- a/pages/404.tsx
+++ b/pages/404.tsx
@@ -1,5 +1,6 @@
-import { Page } from "@components/layout/page";
-import { PageContent } from "@components/layout/page-content";
+import { Page } from "~/components/layout/page";
+import { PageContent } from "~/components/layout/page-content";
+
 import Link from "next/link";
 
 export default function FourOhFour() {

--- a/pages/404.tsx
+++ b/pages/404.tsx
@@ -1,6 +1,5 @@
-import { Page } from "../components/layout/page";
-import { PageContent } from "../components/layout/page-content";
-
+import { Page } from "@components/layout/page";
+import { PageContent } from "@components/layout/page-content";
 import Link from "next/link";
 
 export default function FourOhFour() {

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -4,9 +4,8 @@ import "nprogress/nprogress.css";
 
 import { useEffect } from "react";
 
-import { LayoutRoot } from "../components/layout/layout-root";
-import config from "../lib/config";
-
+import { LayoutRoot } from "@components/layout/layout-root";
+import config from "@lib/config";
 import type { AppProps } from "next/app";
 import Head from "next/head";
 import { DefaultSeo } from "next-seo";

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -4,8 +4,9 @@ import "nprogress/nprogress.css";
 
 import { useEffect } from "react";
 
-import { LayoutRoot } from "@components/layout/layout-root";
-import config from "@lib/config";
+import { LayoutRoot } from "~/components/layout/layout-root";
+import config from "~/lib/config";
+
 import type { AppProps } from "next/app";
 import Head from "next/head";
 import { DefaultSeo } from "next-seo";

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,5 +1,5 @@
-import "@styles/globals.css";
-import "@styles/fonts.css";
+import "~/styles/globals.css";
+import "~/styles/fonts.css";
 import "nprogress/nprogress.css";
 
 import { useEffect } from "react";

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -1,5 +1,5 @@
-import "../styles/globals.css";
-import "../styles/fonts.css";
+import "@styles/globals.css";
+import "@styles/fonts.css";
 import "nprogress/nprogress.css";
 
 import { useEffect } from "react";

--- a/pages/_error.tsx
+++ b/pages/_error.tsx
@@ -1,5 +1,5 @@
-import { Page } from "../components/layout/page";
-import { PageContent } from "../components/layout/page-content";
+import { Page } from "@components/layout/page";
+import { PageContent } from "@components/layout/page-content";
 
 export default function FallbackError() {
   const refreshPage = () => window.location.reload();

--- a/pages/_error.tsx
+++ b/pages/_error.tsx
@@ -1,5 +1,5 @@
-import { Page } from "@components/layout/page";
-import { PageContent } from "@components/layout/page-content";
+import { Page } from "~/components/layout/page";
+import { PageContent } from "~/components/layout/page-content";
 
 export default function FallbackError() {
   const refreshPage = () => window.location.reload();

--- a/pages/faq.tsx
+++ b/pages/faq.tsx
@@ -1,12 +1,13 @@
 import { useMemo } from "react";
 
-import { BackButton } from "@components/layout/back-button";
-import { Page } from "@components/layout/page";
-import { PageContent } from "@components/layout/page-content";
-import { PageHeader } from "@components/layout/page-header";
-import { SearchForm } from "@components/search-form";
-import faqSheets, { FaqData } from "@lib/faq-databases";
-import { useSearch } from "@lib/hooks/use-search";
+import { BackButton } from "~/components/layout/back-button";
+import { Page } from "~/components/layout/page";
+import { PageContent } from "~/components/layout/page-content";
+import { PageHeader } from "~/components/layout/page-header";
+import { SearchForm } from "~/components/search-form";
+import faqSheets, { FaqData } from "~/lib/faq-databases";
+import { useSearch } from "~/lib/hooks/use-search";
+
 import htmr from "htmr";
 import { GetStaticProps } from "next";
 import { NextSeo } from "next-seo";

--- a/pages/faq.tsx
+++ b/pages/faq.tsx
@@ -1,13 +1,12 @@
 import { useMemo } from "react";
 
-import { BackButton } from "../components/layout/back-button";
-import { Page } from "../components/layout/page";
-import { PageContent } from "../components/layout/page-content";
-import { PageHeader } from "../components/layout/page-header";
-import { SearchForm } from "../components/search-form";
-import faqSheets, { FaqData } from "../lib/faq-databases";
-import { useSearch } from "../lib/hooks/use-search";
-
+import { BackButton } from "@components/layout/back-button";
+import { Page } from "@components/layout/page";
+import { PageContent } from "@components/layout/page-content";
+import { PageHeader } from "@components/layout/page-header";
+import { SearchForm } from "@components/search-form";
+import faqSheets, { FaqData } from "@lib/faq-databases";
+import { useSearch } from "@lib/hooks/use-search";
 import htmr from "htmr";
 import { GetStaticProps } from "next";
 import { NextSeo } from "next-seo";

--- a/pages/home-page.tsx
+++ b/pages/home-page.tsx
@@ -1,10 +1,10 @@
 import { attributes, html } from "../_content/home-page.md";
-import { Page } from "../components/layout/page";
-import { PageContent } from "../components/layout/page-content";
-import config from "../lib/config";
-import { bannerBlurData, imgixLoader } from "../lib/imgix-loader";
 
+import { Page } from "@components/layout/page";
+import { PageContent } from "@components/layout/page-content";
 import { ClockIcon } from "@heroicons/react/outline";
+import config from "@lib/config";
+import { bannerBlurData, imgixLoader } from "@lib/imgix-loader";
 import Image from "next/image";
 import Link from "next/link";
 import { NextSeo } from "next-seo";

--- a/pages/home-page.tsx
+++ b/pages/home-page.tsx
@@ -1,10 +1,10 @@
-import { attributes, html } from "../_content/home-page.md";
+import { attributes, html } from "~/_content/home-page.md";
+import { Page } from "~/components/layout/page";
+import { PageContent } from "~/components/layout/page-content";
+import config from "~/lib/config";
+import { bannerBlurData, imgixLoader } from "~/lib/imgix-loader";
 
-import { Page } from "@components/layout/page";
-import { PageContent } from "@components/layout/page-content";
 import { ClockIcon } from "@heroicons/react/outline";
-import config from "@lib/config";
-import { bannerBlurData, imgixLoader } from "@lib/imgix-loader";
 import Image from "next/image";
 import Link from "next/link";
 import { NextSeo } from "next-seo";

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,8 +1,7 @@
-import data from "../data/wbw.json";
-
 import { Page } from "@components/layout/page";
 import { PageContent } from "@components/layout/page-content";
 import { Script } from "@components/script";
+import data from "@data/wbw.json";
 import config from "@lib/config";
 import { bannerBlurData, imgixLoader } from "@lib/imgix-loader";
 import { GetStaticProps } from "next";

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,10 +1,10 @@
-import { Page } from "../components/layout/page";
-import { PageContent } from "../components/layout/page-content";
-import { Script } from "../components/script";
 import data from "../data/wbw.json";
-import config from "../lib/config";
-import { bannerBlurData, imgixLoader } from "../lib/imgix-loader";
 
+import { Page } from "@components/layout/page";
+import { PageContent } from "@components/layout/page-content";
+import { Script } from "@components/script";
+import config from "@lib/config";
+import { bannerBlurData, imgixLoader } from "@lib/imgix-loader";
 import { GetStaticProps } from "next";
 import Head from "next/head";
 import Image from "next/image";

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,9 +1,10 @@
-import { Page } from "@components/layout/page";
-import { PageContent } from "@components/layout/page-content";
-import { Script } from "@components/script";
-import data from "@data/wbw.json";
-import config from "@lib/config";
-import { bannerBlurData, imgixLoader } from "@lib/imgix-loader";
+import { Page } from "~/components/layout/page";
+import { PageContent } from "~/components/layout/page-content";
+import { Script } from "~/components/script";
+import data from "~/data/wbw.json";
+import config from "~/lib/config";
+import { bannerBlurData, imgixLoader } from "~/lib/imgix-loader";
+
 import { GetStaticProps } from "next";
 import Head from "next/head";
 import Image from "next/image";

--- a/pages/provinces/[provinceSlug]/[contactSlug].tsx
+++ b/pages/provinces/[provinceSlug]/[contactSlug].tsx
@@ -1,13 +1,12 @@
 /* eslint-disable no-negated-condition */
-import { ContactDetails } from "../../../components/contact-details";
-import { BackButton } from "../../../components/layout/back-button";
-import { Page } from "../../../components/layout/page";
-import { PageContent } from "../../../components/layout/page-content";
-import { PageHeader } from "../../../components/layout/page-header";
-import { ReportButton } from "../../../components/report-button";
-import provinces, { Contact, getContactsPaths } from "../../../lib/provinces";
-import { getTheLastSegmentFromKebabCase } from "../../../lib/string-utils";
-
+import { ContactDetails } from "@components/contact-details";
+import { BackButton } from "@components/layout/back-button";
+import { Page } from "@components/layout/page";
+import { PageContent } from "@components/layout/page-content";
+import { PageHeader } from "@components/layout/page-header";
+import { ReportButton } from "@components/report-button";
+import provinces, { Contact, getContactsPaths } from "@lib/provinces";
+import { getTheLastSegmentFromKebabCase } from "@lib/string-utils";
 import { GetStaticPaths, GetStaticProps } from "next";
 import { useRouter } from "next/dist/client/router";
 import { NextSeo } from "next-seo";

--- a/pages/provinces/[provinceSlug]/[contactSlug].tsx
+++ b/pages/provinces/[provinceSlug]/[contactSlug].tsx
@@ -1,12 +1,13 @@
 /* eslint-disable no-negated-condition */
-import { ContactDetails } from "@components/contact-details";
-import { BackButton } from "@components/layout/back-button";
-import { Page } from "@components/layout/page";
-import { PageContent } from "@components/layout/page-content";
-import { PageHeader } from "@components/layout/page-header";
-import { ReportButton } from "@components/report-button";
-import provinces, { Contact, getContactsPaths } from "@lib/provinces";
-import { getTheLastSegmentFromKebabCase } from "@lib/string-utils";
+import { ContactDetails } from "~/components/contact-details";
+import { BackButton } from "~/components/layout/back-button";
+import { Page } from "~/components/layout/page";
+import { PageContent } from "~/components/layout/page-content";
+import { PageHeader } from "~/components/layout/page-header";
+import { ReportButton } from "~/components/report-button";
+import provinces, { Contact, getContactsPaths } from "~/lib/provinces";
+import { getTheLastSegmentFromKebabCase } from "~/lib/string-utils";
+
 import { GetStaticPaths, GetStaticProps } from "next";
 import { useRouter } from "next/dist/client/router";
 import { NextSeo } from "next-seo";

--- a/pages/provinces/[provinceSlug]/index.tsx
+++ b/pages/provinces/[provinceSlug]/index.tsx
@@ -1,14 +1,13 @@
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
-import { ContactList } from "../../../components/contact-list";
-import { BackButton } from "../../../components/layout/back-button";
-import { Page } from "../../../components/layout/page";
-import { PageContent } from "../../../components/layout/page-content";
-import { PageHeader } from "../../../components/layout/page-header";
-import { SearchForm } from "../../../components/search-form";
-import { useSearch } from "../../../lib/hooks/use-search";
-import provinces, { Contact, getProvincesPaths } from "../../../lib/provinces";
-import { getTheLastSegmentFromKebabCase } from "../../../lib/string-utils";
-
+import { ContactList } from "@components/contact-list";
+import { BackButton } from "@components/layout/back-button";
+import { Page } from "@components/layout/page";
+import { PageContent } from "@components/layout/page-content";
+import { PageHeader } from "@components/layout/page-header";
+import { SearchForm } from "@components/search-form";
+import { useSearch } from "@lib/hooks/use-search";
+import provinces, { Contact, getProvincesPaths } from "@lib/provinces";
+import { getTheLastSegmentFromKebabCase } from "@lib/string-utils";
 import { GetStaticPaths, GetStaticProps } from "next";
 import { useRouter } from "next/router";
 import { NextSeo } from "next-seo";

--- a/pages/provinces/[provinceSlug]/index.tsx
+++ b/pages/provinces/[provinceSlug]/index.tsx
@@ -1,13 +1,14 @@
 /* eslint-disable @typescript-eslint/no-unsafe-assignment */
-import { ContactList } from "@components/contact-list";
-import { BackButton } from "@components/layout/back-button";
-import { Page } from "@components/layout/page";
-import { PageContent } from "@components/layout/page-content";
-import { PageHeader } from "@components/layout/page-header";
-import { SearchForm } from "@components/search-form";
-import { useSearch } from "@lib/hooks/use-search";
-import provinces, { Contact, getProvincesPaths } from "@lib/provinces";
-import { getTheLastSegmentFromKebabCase } from "@lib/string-utils";
+import { ContactList } from "~/components/contact-list";
+import { BackButton } from "~/components/layout/back-button";
+import { Page } from "~/components/layout/page";
+import { PageContent } from "~/components/layout/page-content";
+import { PageHeader } from "~/components/layout/page-header";
+import { SearchForm } from "~/components/search-form";
+import { useSearch } from "~/lib/hooks/use-search";
+import provinces, { Contact, getProvincesPaths } from "~/lib/provinces";
+import { getTheLastSegmentFromKebabCase } from "~/lib/string-utils";
+
 import { GetStaticPaths, GetStaticProps } from "next";
 import { useRouter } from "next/router";
 import { NextSeo } from "next-seo";

--- a/pages/provinces/index.tsx
+++ b/pages/provinces/index.tsx
@@ -1,13 +1,12 @@
-import { BackButton } from "../../components/layout/back-button";
-import { Page } from "../../components/layout/page";
-import { PageContent } from "../../components/layout/page-content";
-import { PageHeader } from "../../components/layout/page-header";
-import { ProvinceList, ProvinceListItem } from "../../components/province-list";
-import { SearchForm } from "../../components/search-form";
-import { useSearch } from "../../lib/hooks/use-search";
-import provinces from "../../lib/provinces";
-import { getInitial, getSlug } from "../../lib/string-utils";
-
+import { BackButton } from "@components/layout/back-button";
+import { Page } from "@components/layout/page";
+import { PageContent } from "@components/layout/page-content";
+import { PageHeader } from "@components/layout/page-header";
+import { ProvinceList, ProvinceListItem } from "@components/province-list";
+import { SearchForm } from "@components/search-form";
+import { useSearch } from "@lib/hooks/use-search";
+import provinces from "@lib/provinces";
+import { getInitial, getSlug } from "@lib/string-utils";
 import { GetStaticProps } from "next";
 import { NextSeo } from "next-seo";
 

--- a/pages/provinces/index.tsx
+++ b/pages/provinces/index.tsx
@@ -1,12 +1,13 @@
-import { BackButton } from "@components/layout/back-button";
-import { Page } from "@components/layout/page";
-import { PageContent } from "@components/layout/page-content";
-import { PageHeader } from "@components/layout/page-header";
-import { ProvinceList, ProvinceListItem } from "@components/province-list";
-import { SearchForm } from "@components/search-form";
-import { useSearch } from "@lib/hooks/use-search";
-import provinces from "@lib/provinces";
-import { getInitial, getSlug } from "@lib/string-utils";
+import { BackButton } from "~/components/layout/back-button";
+import { Page } from "~/components/layout/page";
+import { PageContent } from "~/components/layout/page-content";
+import { PageHeader } from "~/components/layout/page-header";
+import { ProvinceList, ProvinceListItem } from "~/components/province-list";
+import { SearchForm } from "~/components/search-form";
+import { useSearch } from "~/lib/hooks/use-search";
+import provinces from "~/lib/provinces";
+import { getInitial, getSlug } from "~/lib/string-utils";
+
 import { GetStaticProps } from "next";
 import { NextSeo } from "next-seo";
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,7 +13,19 @@
     "skipLibCheck": true,
     "strict": true,
     "target": "es5",
-    "typeRoots": ["./@types", "./node_modules/@types"]
+    "typeRoots": ["./@types", "./node_modules/@types"],
+    "baseUrl": "./",
+    "paths": {
+      "@components/*": [
+        "./components/*"
+      ],
+      "@styles/*": [
+        "./styles/*"
+      ],
+      "@lib/*": [
+        "./lib/*"
+      ],
+    }
   },
   "exclude": ["node_modules"],
   "include": ["env.d.ts", "next-env.d.ts", "**/*.ts", "**/*.tsx"],

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,10 +16,7 @@
     "typeRoots": ["./@types", "./node_modules/@types"],
     "baseUrl": "./",
     "paths": {
-      "@components/*": ["./components/*"],
-      "@styles/*": ["./styles/*"],
-      "@lib/*": ["./lib/*"],
-      "@data/*": ["./data/*"]
+      "~/*": ["./*"]
     }
   },
   "exclude": ["node_modules"],

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,15 +16,10 @@
     "typeRoots": ["./@types", "./node_modules/@types"],
     "baseUrl": "./",
     "paths": {
-      "@components/*": [
-        "./components/*"
-      ],
-      "@styles/*": [
-        "./styles/*"
-      ],
-      "@lib/*": [
-        "./lib/*"
-      ],
+      "@components/*": ["./components/*"],
+      "@styles/*": ["./styles/*"],
+      "@lib/*": ["./lib/*"],
+      "@data/*": ["./data/*"]
     }
   },
   "exclude": ["node_modules"],


### PR DESCRIPTION
Closes https://github.com/kawalcovid19/wargabantuwarga.com/issues/225

## Description

Configure tsconfig.json for module path alias with leading `~` from base URL (`./`).

example: `import { PageContent } from "~/components/layout/page-content";`

Nextjs and eslint use tsconfig, might need to update other utilities such as test runner later when it exists to support the path alias.

ref: https://nextjs.org/docs/advanced-features/module-path-aliases

## Current Tasks

- [x] configure tsconfig 
- [x] update current path references
