### PR TITLE
Improve province search #347

### DIFF
--- a/components/search-form.tsx
+++ b/components/search-form.tsx
@@ -33,6 +33,7 @@ type SortSetting = {
 
 export function SearchForm({
   itemName,
+  placeholderText,
   checkDocSize,
   onSubmitKeywords,
   filterItems,
@@ -42,6 +43,7 @@ export function SearchForm({
   isLoading,
 }: {
   itemName: string;
+  placeholderText: string;
   checkDocSize: boolean;
   onSubmitKeywords: (keywords: string, filters?: any, sort_by?: string) => void;
   filterItems?: {};
@@ -128,6 +130,7 @@ export function SearchForm({
             autoComplete="off"
             id="keywordsInput"
             onChange={handleKeywordsChange}
+            placeholder={placeholderText}
             type="text"
             value={keywords}
           />

--- a/components/search-form.tsx
+++ b/components/search-form.tsx
@@ -36,25 +36,25 @@ export function SearchForm({
   placeholderText,
   checkDocSize,
   onSubmitKeywords,
-  filterItems,
-  sortSettings,
   autoSearch,
+  filterItems,
   initialValue,
   isLoading,
+  sortSettings,
 }: {
   itemName: string;
   placeholderText: string;
   checkDocSize: boolean;
   onSubmitKeywords: (keywords: string, filters?: any, sort_by?: string) => void;
-  filterItems?: {};
-  sortSettings?: SortSetting[];
   autoSearch?: boolean;
+  filterItems?: {};
   initialValue?: {
     query?: string;
     filters?: {};
     sort?: string;
   };
   isLoading?: boolean;
+  sortSettings?: SortSetting[];
 }) {
   const defaultSort = sortSettings?.length ? sortSettings[0].value : "";
   const [keywords, setKeywords] = useState<string>("");

--- a/components/search-form.tsx
+++ b/components/search-form.tsx
@@ -43,7 +43,7 @@ export function SearchForm({
   sortSettings,
 }: {
   itemName: string;
-  placeholderText: string;
+  placeholderText?: string;
   checkDocSize: boolean;
   onSubmitKeywords: (keywords: string, filters?: any, sort_by?: string) => void;
   autoSearch?: boolean;

--- a/pages/provinces/[provinceSlug]/index.tsx
+++ b/pages/provinces/[provinceSlug]/index.tsx
@@ -100,6 +100,7 @@ export default function ProvincePage(props: ProvinceProps) {
             isLoading={isLoading}
             itemName="kontak"
             onSubmitKeywords={handleSubmitKeywords}
+            placeholderText="Cari berdasarkan kontak, alamat, provider, dan keterangan"
             sortSettings={[
               { value: "verified_first", label: "Terverifikasi" },
               { value: "penyedia_asc", label: "Nama" },


### PR DESCRIPTION
Closes #347

## Description

The user may not know that he/she can search by address, provider, description and ofcourse the contact number, then look for it by the contact number only.

## Current Tasks

- [x] Adding a placeholder to the input with text "Cari berdasarkan kontak, alamat, provider, dan keterangan"
