### PR TITLE
Fix Province Search Bug on Letter A

### DIFF
--- a/lib/hooks/use-search.ts
+++ b/lib/hooks/use-search.ts
@@ -25,6 +25,7 @@ export function useSearch<T = unknown[]>({
 }) {
   const configuration: any = {
     searchableFields: fieldNames,
+    isExactSearch: true,
     sortings: {
       default: {
         field: "id",


### PR DESCRIPTION
Closes #362 

## Description

Since itemsjs using lunr.js, `a` is included as stop words and filtered. 
Since our data is in Bahasa Indonesia, this process is unnecessary.
Itemsjs has isExactSearch setting on the configuration to show exact search matches related to this matter. 

## Current Tasks
- [x] Update isExactSearch in config as `true`
- [x] Test with some words from lunr.js stop word filter https://github.com/olivernn/lunr.js/blob/master/lib/stop_word_filter.js
- [x] Provide screenshot

Fix vs current 

test case: `a`

![image](https://user-images.githubusercontent.com/9606523/126812495-0b53e791-4589-46dd-9f55-39c7b43adf26.png)

test case: `be`

![image](https://user-images.githubusercontent.com/9606523/126812459-4c29b977-f8e1-467e-af1f-0da3eeda3eb8.png)

test case: `he`

![image](https://user-images.githubusercontent.com/9606523/126812864-ffa96aca-de1e-41da-9384-3a63c9419f4e.png)

