### PR TITLE
make banner image path not required

### DIFF
--- a/public/admin/config.yml
+++ b/public/admin/config.yml
@@ -60,4 +60,5 @@ collections:
               name: "home_banner_image_path",
               widget: "string",
               hint: "Cloudinary image path, eg. `v12345/my_file.png`",
+              required: false,
             }


### PR DESCRIPTION
## Description

Fixes a regression in Netlify CMS after #390 where the banner image is not meant to be required.

![image](https://user-images.githubusercontent.com/5663877/126890606-0e1ebae3-125b-429b-864e-cb56b4bde722.png)

