### PR TITLE
fix(ci): netlify preview action error on main

### DIFF
--- a/.github/workflows/lighthouse-ci-prod.yml
+++ b/.github/workflows/lighthouse-ci-prod.yml
@@ -1,15 +1,13 @@
-name: Web Perf Check for Pull Request
+name: Web Perf Check
 
 on:
-  pull_request:
-    types: [labeled]
+  push:
+    branches: [main]
 
 jobs:
   lhci:
-    name: Run Lighthouse CI for Pull Request
+    name: Run Lighthouse CI on Production
     runs-on: ubuntu-latest
-
-    if: ${{ !contains(github.event.pull_request.labels.*.names, 'need-perf-check') }}
 
     steps:
       - uses: actions/checkout@v2
@@ -18,12 +16,6 @@ jobs:
         with:
           node-version: "14"
 
-      - name: Wait for the Netlify Preview
-        uses: jakepartusch/wait-for-netlify-action@v1
-        id: netlify
-        with:
-          site_name: 'wargabantuwarga'
-
       - name: "Lighthouse CI assertion"
         id: lhci
         shell: bash
@@ -31,7 +23,7 @@ jobs:
           yarn global add @lhci/cli@0.8.x
           echo -e "\n"
           echo "Start collecting LH report..."
-          lhci collect --url=${{ steps.netlify.outputs.url }} -n=1
+          lhci collect --url=https://www.wargabantuwarga.com/ -n=1
           echo -e "\n"
           echo "Start asserting LH score..."
           lhci assert --config=./lighthouserc.js


### PR DESCRIPTION
## Description

Action `jakepartusch/wait-for-netlify-action@v1` will failed on `main` branches, we need to split the CI for main and pull-request

## Current Tasks

- [x] Split the workflow
- [x] Remove netlify-wait on `main` branch
- [x] Use hardcode production url
