### PR TITLE
fix: Revert back to mirror-box

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "lint": "eslint \"**/*.{js,jsx,ts,tsx}\"",
     "lint:fix": "eslint --fix \"**/*.{js,jsx,ts,tsx}\"",
     "mirror-box": "ts-node etc/mirror-box.ts",
-    "netlify-export": "yarn fetch-wbw && yarn build && next export",
+    "netlify-export": "yarn mirror-box && yarn build && next export",
     "prepare": "husky install",
     "start": "next start",
     "cypress:open": "cypress open",


### PR DESCRIPTION
Closes #412

## Description

Revert back to `mirror-box` from `fetch-wbw` due to #361.

## Current Tasks

<!-- List the tasks that you're planning to do in this PR.
This is to indicate how much you have been progressing before this PR is ready for review -->

- [x] Replace `fetch-wbw` with `mirror-box` 
