### PR TITLE
fix(gtm): move noscript under body

### DIFF
--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -6,6 +6,7 @@ import "typeface-inter";
 import { useEffect } from "react";
 
 import { LayoutRoot } from "~/components/layout/layout-root";
+import { Script } from "~/components/script";
 import config from "~/lib/config";
 
 import type { AppProps } from "next/app";
@@ -82,6 +83,17 @@ export default function App({ Component, pageProps, router }: AppProps) {
         <link href="/manifest.json" rel="manifest" />
         <meta content="#1667C2" name="theme-color" />
       </Head>
+
+      <Script
+        dangerouslySetInnerHTML={{
+          __html: `(function(w,d,s,l,i){w[l] = w[l] || [];w[l].push({'gtm.start':
+new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+})(window,document,'script','dataLayer','GTM-5X4ZPBX');`,
+        }}
+      />
+
       <Component {...pageProps} />
     </LayoutRoot>
   );

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -6,7 +6,6 @@ import "typeface-inter";
 import { useEffect } from "react";
 
 import { LayoutRoot } from "~/components/layout/layout-root";
-import { Script } from "~/components/script";
 import config from "~/lib/config";
 
 import type { AppProps } from "next/app";
@@ -83,25 +82,6 @@ export default function App({ Component, pageProps, router }: AppProps) {
         <link href="/manifest.json" rel="manifest" />
         <meta content="#1667C2" name="theme-color" />
       </Head>
-
-      <Script
-        dangerouslySetInnerHTML={{
-          __html: `(function(w,d,s,l,i){w[l] = w[l] || [];w[l].push({'gtm.start':
-new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
-j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
-'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-})(window,document,'script','dataLayer','GTM-5X4ZPBX');`,
-        }}
-      />
-      <noscript>
-        <iframe
-          height="0"
-          src="https://www.googletagmanager.com/ns.html?id=GTM-5X4ZPBX"
-          style={{ display: "none", visibility: "hidden" }}
-          title="gtm"
-          width="0"
-        />
-      </noscript>
       <Component {...pageProps} />
     </LayoutRoot>
   );

--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -1,5 +1,3 @@
-import { Script } from "~/components/script";
-
 import Document, { Head, Html, Main, NextScript } from "next/document";
 
 export default class MyDocument extends Document {
@@ -11,15 +9,6 @@ export default class MyDocument extends Document {
           <meta content="ie=edge" httpEquiv="X-UA-Compatible" />
         </Head>
         <body>
-          <Script
-            dangerouslySetInnerHTML={{
-              __html: `(function(w,d,s,l,i){w[l] = w[l] || [];w[l].push({'gtm.start':
-new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
-j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
-'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-})(window,document,'script','dataLayer','GTM-5X4ZPBX');`,
-            }}
-          />
           <noscript>
             <iframe
               height="0"

--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -1,3 +1,5 @@
+import { Script } from "~/components/script";
+
 import Document, { Head, Html, Main, NextScript } from "next/document";
 
 export default class MyDocument extends Document {
@@ -9,6 +11,24 @@ export default class MyDocument extends Document {
           <meta content="ie=edge" httpEquiv="X-UA-Compatible" />
         </Head>
         <body>
+          <Script
+            dangerouslySetInnerHTML={{
+              __html: `(function(w,d,s,l,i){w[l] = w[l] || [];w[l].push({'gtm.start':
+new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+})(window,document,'script','dataLayer','GTM-5X4ZPBX');`,
+            }}
+          />
+          <noscript>
+            <iframe
+              height="0"
+              src="https://www.googletagmanager.com/ns.html?id=GTM-5X4ZPBX"
+              style={{ display: "none", visibility: "hidden" }}
+              title="gtm"
+              width="0"
+            />
+          </noscript>
           <Main />
           <NextScript />
         </body>


### PR DESCRIPTION
Closes issue on #419 

## Description

Move GTM under the body

## Current Tasks

- [x] Move GTM to be precise under the body
- [x] Move the `noscript` from `_app` to `_document`

![Screen Shot 2021-07-26 at 11 30 12](https://user-images.githubusercontent.com/7221389/126933202-81fdf0ce-717a-4701-a9bf-3c3224908eaa.png)
