### PR TITLE
fix: remove trailing semicolon at homepage

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -80,7 +80,7 @@ const HomePage = () => (
         <LastUpdatedAlert className="mt-3 mb-3" />
         <HomePageSection>
           <article className="prose prose-indigo">
-            {htmr(html, { transform: htmrTransform })};
+            {htmr(html, { transform: htmrTransform })}
           </article>
         </HomePageSection>
         <style jsx>{`


### PR DESCRIPTION
Closes #464

## Description

Removes trailing semicolon at the homepage.
