### PR TITLE
Implement static slug for `Contact` page and add more tests to verify the changes

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
         with:
           node-version: "14"
       - run: yarn install --frozen-lockfile
-      - run: yarn run mirror-box
+      - run: yarn run fetch-wbw
       - uses: actions/cache@v1
         id: cache-deps
         with:

--- a/__tests__/pages/provinces/[provinceSlug]/[contactSlug].test.tsx
+++ b/__tests__/pages/provinces/[provinceSlug]/[contactSlug].test.tsx
@@ -1,7 +1,9 @@
 import React from "react";
 
 import provinces from "~/lib/provinces";
-import ContactPage from "~/pages/provinces/[provinceSlug]/[contactSlug]";
+import ContactPage, {
+  getStaticPaths,
+} from "~/pages/provinces/[provinceSlug]/[contactSlug]";
 
 import { render, screen } from "@testing-library/react";
 
@@ -36,5 +38,22 @@ describe("ContactPage", () => {
       `/provinces/${province.slug}/${contact.slug}`,
     );
     expect(title).toBeVisible();
+  });
+});
+
+describe("getStaticPaths", () => {
+  it("returns the correct paths", () => {
+    const paths = provinces.flatMap((province) =>
+      province.data.map((contact) => ({
+        params: {
+          provinceSlug: province.slug,
+          contactSlug: contact.slug,
+        },
+      })),
+    );
+    expect(getStaticPaths({})).toEqual({
+      fallback: false,
+      paths,
+    });
   });
 });

--- a/__tests__/pages/provinces/[provinceSlug]/[contactSlug].test.tsx
+++ b/__tests__/pages/provinces/[provinceSlug]/[contactSlug].test.tsx
@@ -1,0 +1,40 @@
+import React from "react";
+
+import provinces from "~/lib/provinces";
+import ContactPage from "~/pages/provinces/[provinceSlug]/[contactSlug]";
+
+import { render, screen } from "@testing-library/react";
+
+jest.mock("~/lib/provinces");
+
+describe("ContactPage", () => {
+  const [province] = provinces;
+  const [contact] = province.data;
+
+  it("renders the title and the breadcrumbs correctly", () => {
+    render(
+      <ContactPage
+        contact={contact}
+        provinceName={province.name}
+        provinceSlug={province.slug}
+      />,
+    );
+
+    const provinceBreadcrumbs = screen.getByText(province.name);
+    expect(provinceBreadcrumbs).toBeVisible();
+    expect(provinceBreadcrumbs).toHaveAttribute(
+      "href",
+      `/provinces/${province.slug}`,
+    );
+
+    const [contactBreadcrumbs, title] = screen.getAllByText(
+      contact.penyedia as string,
+    );
+    expect(contactBreadcrumbs).toBeVisible();
+    expect(contactBreadcrumbs).toHaveAttribute(
+      "href",
+      `/provinces/${province.slug}/${contact.slug}`,
+    );
+    expect(title).toBeVisible();
+  });
+});

--- a/__tests__/pages/provinces/[provinceSlug]/[contactSlug].test.tsx
+++ b/__tests__/pages/provinces/[provinceSlug]/[contactSlug].test.tsx
@@ -76,4 +76,12 @@ describe("getStaticProps", () => {
       },
     });
   });
+
+  it("returns an empty provinceName only given an empty params", () => {
+    expect(getStaticProps({})).toEqual({
+      props: {
+        provinceName: "",
+      },
+    });
+  });
 });

--- a/__tests__/pages/provinces/[provinceSlug]/[contactSlug].test.tsx
+++ b/__tests__/pages/provinces/[provinceSlug]/[contactSlug].test.tsx
@@ -1,11 +1,13 @@
 import React from "react";
 
+import { contactBuilder } from "~/lib/__mocks__/builders/provinces";
 import provinces from "~/lib/provinces";
 import ContactPage, {
   getStaticPaths,
   getStaticProps,
 } from "~/pages/provinces/[provinceSlug]/[contactSlug]";
 
+import { perBuild } from "@jackfranklin/test-data-bot";
 import { render, screen } from "@testing-library/react";
 
 jest.mock("~/lib/provinces");
@@ -37,6 +39,39 @@ describe("ContactPage", () => {
     expect(contactBreadcrumbs).toHaveAttribute(
       "href",
       `/provinces/${province.slug}/${contact.slug}`,
+    );
+    expect(title).toBeVisible();
+  });
+
+  it.only("fallbacks to `keterangan` if `penyedia` is not available", () => {
+    const contactWithoutPenyedia = contactBuilder({
+      overrides: {
+        penyedia: perBuild(() => undefined),
+      },
+    });
+
+    render(
+      <ContactPage
+        contact={contactWithoutPenyedia}
+        provinceName={province.name}
+        provinceSlug={province.slug}
+      />,
+    );
+
+    const provinceBreadcrumbs = screen.getByText(province.name);
+    expect(provinceBreadcrumbs).toBeVisible();
+    expect(provinceBreadcrumbs).toHaveAttribute(
+      "href",
+      `/provinces/${province.slug}`,
+    );
+
+    const [contactBreadcrumbs, title] = screen.getAllByText(
+      contactWithoutPenyedia.keterangan as string,
+    );
+    expect(contactBreadcrumbs).toBeVisible();
+    expect(contactBreadcrumbs).toHaveAttribute(
+      "href",
+      `/provinces/${province.slug}/${contactWithoutPenyedia.slug}`,
     );
     expect(title).toBeVisible();
   });

--- a/__tests__/pages/provinces/[provinceSlug]/[contactSlug].test.tsx
+++ b/__tests__/pages/provinces/[provinceSlug]/[contactSlug].test.tsx
@@ -3,6 +3,7 @@ import React from "react";
 import provinces from "~/lib/provinces";
 import ContactPage, {
   getStaticPaths,
+  getStaticProps,
 } from "~/pages/provinces/[provinceSlug]/[contactSlug]";
 
 import { render, screen } from "@testing-library/react";
@@ -54,6 +55,25 @@ describe("getStaticPaths", () => {
     expect(getStaticPaths({})).toEqual({
       fallback: false,
       paths,
+    });
+  });
+});
+
+describe("getStaticProps", () => {
+  const [province] = provinces;
+  const [contact] = province.data;
+
+  it("gets the contact from the provinceSlug and contactSlug params", () => {
+    expect(
+      getStaticProps({
+        params: { provinceSlug: province.slug, contactSlug: contact.slug },
+      }),
+    ).toEqual({
+      props: {
+        provinceSlug: province.slug,
+        provinceName: province.name,
+        contact,
+      },
     });
   });
 });

--- a/etc/fetchers/fetch-sheets.ts
+++ b/etc/fetchers/fetch-sheets.ts
@@ -1,6 +1,7 @@
 import {
   allIsEmptyString,
   getKebabCase,
+  stripTags,
   toSnakeCase,
   toTitleCase,
 } from "../../lib/string-utils";
@@ -69,10 +70,14 @@ export async function fetchSheets() {
                 cellValue = toTitleCase(cellValue);
               }
               prev[colName] = cellValue;
-              if (colName == "penyedia") {
-                prev.slug = getKebabCase(
-                  (prev.penyedia || prev.keterangan) as string,
-                );
+              if (colName == "kontak") {
+                prev.slug = [
+                  getKebabCase(prev.kebutuhan as string),
+                  getKebabCase(prev.keterangan as string),
+                  getKebabCase(prev.lokasi as string),
+                  getKebabCase(prev.penyedia as string),
+                  getKebabCase(stripTags(prev.kontak as string)),
+                ].join("-");
               } else if (colName == "terakhir_update") {
                 prev.verifikasi = cellValue == "" ? 0 : 1;
               }

--- a/etc/fetchers/fetch-sheets.ts
+++ b/etc/fetchers/fetch-sheets.ts
@@ -1,7 +1,6 @@
 import {
   allIsEmptyString,
   getKebabCase,
-  getSlug,
   toSnakeCase,
   toTitleCase,
 } from "../../lib/string-utils";
@@ -71,9 +70,8 @@ export async function fetchSheets() {
               }
               prev[colName] = cellValue;
               if (colName == "penyedia") {
-                prev.slug = getSlug(
+                prev.slug = getKebabCase(
                   (prev.penyedia || prev.keterangan) as string,
-                  rowIndex,
                 );
               } else if (colName == "terakhir_update") {
                 prev.verifikasi = cellValue == "" ? 0 : 1;

--- a/jest.config.js
+++ b/jest.config.js
@@ -7,10 +7,10 @@ module.exports = {
   ],
   coverageThreshold: {
     global: {
-      statements: 49,
-      branches: 41,
-      functions: 51,
-      lines: 49,
+      statements: 53,
+      branches: 44,
+      functions: 56,
+      lines: 53,
     },
   },
   transform: {

--- a/jest.config.js
+++ b/jest.config.js
@@ -7,10 +7,10 @@ module.exports = {
   ],
   coverageThreshold: {
     global: {
-      statements: 53,
-      branches: 44,
-      functions: 57,
-      lines: 54,
+      statements: 56,
+      branches: 46,
+      functions: 61,
+      lines: 56,
     },
   },
   transform: {

--- a/jest.config.js
+++ b/jest.config.js
@@ -9,7 +9,7 @@ module.exports = {
     global: {
       statements: 56,
       branches: 46,
-      functions: 61,
+      functions: 60,
       lines: 56,
     },
   },

--- a/jest.config.js
+++ b/jest.config.js
@@ -9,8 +9,8 @@ module.exports = {
     global: {
       statements: 53,
       branches: 44,
-      functions: 56,
-      lines: 53,
+      functions: 57,
+      lines: 54,
     },
   },
   transform: {

--- a/lib/__mocks__/builders/provinces.ts
+++ b/lib/__mocks__/builders/provinces.ts
@@ -25,6 +25,7 @@ export const contactBuilder = build<Contact>({
       "Tes swab",
     ),
     penyedia: fake((f) => f.company.companyName()),
+    keterangan: fake((f) => f.commerce.productName()),
     kontak: fake((f) => f.phone.phoneNumber()),
     verifikasi: 1,
   },

--- a/lib/__mocks__/provinces.ts
+++ b/lib/__mocks__/provinces.ts
@@ -1,19 +1,5 @@
-import { Province, ProvincePath } from "../provinces";
-
 import { provinceBuilder } from "./builders/provinces";
 
 const provinces = [provinceBuilder(), provinceBuilder()];
-
-export const getProvincesPaths = (): ProvincePath[] => {
-  const provincees = provinces as unknown as Province[];
-
-  return provincees.map((province) => {
-    const provinceSlug = province.slug;
-
-    return {
-      params: { provinceSlug },
-    };
-  });
-};
 
 export default provinces;

--- a/lib/__tests__/provinces.test.ts
+++ b/lib/__tests__/provinces.test.ts
@@ -1,0 +1,35 @@
+import provinces from "../provinces";
+import { getKebabCase, stripTags } from "../string-utils";
+
+describe("provinces", () => {
+  it("should returns a list of provinces with the correct province slug", () => {
+    const [province1, province2] = provinces;
+
+    expect(province1.slug).toEqual(getKebabCase(province1.name));
+    expect(province2.slug).toEqual(getKebabCase(province2.name));
+  });
+
+  it("should returns lists of contacts within provinces with the correct contact slug", () => {
+    const [province1] = provinces;
+    const [contact1, contact2] = province1.data;
+
+    expect(contact1.slug).toEqual(
+      [
+        getKebabCase(contact1.kebutuhan as string),
+        getKebabCase(contact1.keterangan as string),
+        getKebabCase(contact1.lokasi as string),
+        getKebabCase(contact1.penyedia as string),
+        getKebabCase(stripTags(contact1.kontak as string)),
+      ].join("-"),
+    );
+    expect(contact2.slug).toEqual(
+      [
+        getKebabCase(contact2.kebutuhan as string),
+        getKebabCase(contact2.keterangan as string),
+        getKebabCase(contact2.lokasi as string),
+        getKebabCase(contact2.penyedia as string),
+        getKebabCase(stripTags(contact2.kontak as string)),
+      ].join("-"),
+    );
+  });
+});

--- a/lib/__tests__/string-utils.test.ts
+++ b/lib/__tests__/string-utils.test.ts
@@ -2,7 +2,6 @@ import {
   allIsEmptyString,
   getInitial,
   getKebabCase,
-  getTheLastSegmentFromKebabCase,
   isNotEmpty,
   toSnakeCase,
   toTitleCase,
@@ -90,19 +89,6 @@ describe("allIsEmptyString", () => {
     "should return '$expected' when '$input' is provided",
     ({ input, expected }) => {
       expect(allIsEmptyString(input as string[])).toBe(expected);
-    },
-  );
-});
-
-describe("getTheLastSegmentFromKebabCase", () => {
-  it.each`
-    input                    | expected
-    ${"dki-jakarta"}         | ${"jakarta"}
-    ${"jakarta-bukan-pusat"} | ${"pusat"}
-  `(
-    "should return '$expected' when '$input' is provided",
-    ({ input, expected }) => {
-      expect(getTheLastSegmentFromKebabCase(input as string)).toBe(expected);
     },
   );
 });

--- a/lib/province-utils.ts
+++ b/lib/province-utils.ts
@@ -1,0 +1,32 @@
+import provinces, { Contact, ProvincePath } from "./provinces";
+
+export const getProvincesPaths = (): ProvincePath[] => {
+  return provinces.map((province) => {
+    const provinceSlug = province.slug;
+
+    return {
+      params: { provinceSlug },
+    };
+  });
+};
+
+export type ContactPath = {
+  params: {
+    provinceSlug: string;
+    contactSlug: string;
+  };
+};
+
+export const getContactsPaths = (): ContactPath[] => {
+  const contactsPaths: ContactPath[] = [];
+  provinces.forEach((province) => {
+    province.data.forEach((contact: Contact) => {
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+      const provinceSlug = province.slug;
+      contactsPaths.push({
+        params: { provinceSlug, contactSlug: contact.slug },
+      });
+    });
+  });
+  return contactsPaths;
+};

--- a/lib/provinces.ts
+++ b/lib/provinces.ts
@@ -11,7 +11,7 @@ export type Province = {
 
 export type Contact = {
   readonly id: string;
-  slug: string;
+  readonly slug: string;
   readonly kebutuhan?: string;
   readonly keterangan?: string;
   readonly lokasi?: string;

--- a/lib/provinces.ts
+++ b/lib/provinces.ts
@@ -11,7 +11,7 @@ export type Province = {
 
 export type Contact = {
   readonly id: string;
-  readonly slug: string;
+  slug: string;
   readonly kebutuhan?: string;
   readonly keterangan?: string;
   readonly lokasi?: string;

--- a/lib/provinces.ts
+++ b/lib/provinces.ts
@@ -31,37 +31,11 @@ export type ProvincePath = {
   };
 };
 
-export const getProvincesPaths = (): ProvincePath[] => {
-  const provincees = provinces as unknown as Province[];
-
-  return provincees.map((province) => {
-    const provinceSlug = province.slug;
-
-    return {
-      params: { provinceSlug },
-    };
-  });
-};
-
 export type ContactPath = {
   params: {
     provinceSlug: string;
     contactSlug: string;
   };
-};
-
-export const getContactsPaths = (): ContactPath[] => {
-  const contactsPaths: ContactPath[] = [];
-  provinces.forEach((province) => {
-    province.data.forEach((contact: Contact) => {
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
-      const provinceSlug = province.slug;
-      contactsPaths.push({
-        params: { provinceSlug, contactSlug: contact.slug },
-      });
-    });
-  });
-  return contactsPaths;
 };
 
 export default provinces as unknown as Provinces;

--- a/lib/string-utils.ts
+++ b/lib/string-utils.ts
@@ -55,18 +55,6 @@ export function getKebabCase(str?: string): string {
 }
 
 /**
- * Get slug from slug identifier and slug index
- *
- * @param {string} name slug identifier
- * @param {number} index slug index
- * @returns {string} slug string
- */
-export function getSlug(name: string, index: number): string {
-  const kebabName = getKebabCase(name);
-  return `${kebabName}-${index}`;
-}
-
-/**
  * Checks if all strings in an array are empty strings
  *
  * @param {string[]} array input array
@@ -86,18 +74,6 @@ export function allIsEmptyString(array: string[]) {
  */
 export function toSecond(hrtime: [number, number]): string {
   return (hrtime[0] + hrtime[1] / 1e9).toFixed(3);
-}
-
-/**
- * Get the last segment from a kebab-cased string
- *
- * @param {string} str input string
- * @returns {string} the last segment of `str`
- */
-export function getTheLastSegmentFromKebabCase(
-  str: string,
-): string | undefined {
-  return str.split("-").pop();
 }
 
 /**

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "lint": "eslint \"**/*.{js,jsx,ts,tsx}\"",
     "lint:fix": "eslint --fix \"**/*.{js,jsx,ts,tsx}\"",
     "mirror-box": "ts-node etc/mirror-box.ts",
-    "netlify-export": "yarn mirror-box && yarn build && next export",
+    "netlify-export": "yarn fetch-wbw && yarn build && next export",
     "prepare": "husky install",
     "start": "next start",
     "cypress:open": "cypress open",

--- a/pages/provinces/[provinceSlug]/[contactSlug].tsx
+++ b/pages/provinces/[provinceSlug]/[contactSlug].tsx
@@ -10,7 +10,6 @@ import provinces, { Contact, getContactsPaths } from "~/lib/provinces";
 import { getTheLastSegmentFromKebabCase } from "~/lib/string-utils";
 
 import { GetStaticPaths, GetStaticProps } from "next";
-import { useRouter } from "next/dist/client/router";
 import { NextSeo } from "next-seo";
 
 type ContactPageProps = {
@@ -22,8 +21,8 @@ type ContactPageProps = {
 export default function ContactPage({
   contact,
   provinceName,
+  provinceSlug,
 }: ContactPageProps) {
-  const router = useRouter();
   const meta = getContactMeta(provinceName, contact);
 
   return (
@@ -34,9 +33,7 @@ export default function ContactPage({
         title={meta.title}
       />
       <PageHeader
-        backButton={
-          <BackButton href={`/provinces/${router.query.provinceSlug}`} />
-        }
+        backButton={<BackButton href={`/provinces/${provinceSlug}`} />}
         breadcrumbs={[
           {
             name: "Provinsi",
@@ -44,13 +41,13 @@ export default function ContactPage({
           },
           {
             name: provinceName,
-            href: `/provinces/${router.query.provinceSlug}`,
+            href: `/provinces/${provinceSlug}`,
           },
           {
             name: contact.penyedia
               ? contact.penyedia
               : contact.keterangan ?? "",
-            href: `/provinces/${router.query.provinceSlug}/${router.query.contactSlug}`,
+            href: `/provinces/${provinceSlug}/${contact.slug}`,
             current: true,
           },
         ]}

--- a/pages/provinces/[provinceSlug]/[contactSlug].tsx
+++ b/pages/provinces/[provinceSlug]/[contactSlug].tsx
@@ -6,7 +6,8 @@ import { PageContent } from "~/components/layout/page-content";
 import { PageHeader } from "~/components/layout/page-header";
 import { ReportButton } from "~/components/report-button";
 import { getContactMeta } from "~/lib/meta";
-import provinces, { Contact, getContactsPaths } from "~/lib/provinces";
+import { getContactsPaths } from "~/lib/province-utils";
+import provinces, { Contact } from "~/lib/provinces";
 import { getTheLastSegmentFromKebabCase } from "~/lib/string-utils";
 
 import { GetStaticPaths, GetStaticProps } from "next";

--- a/pages/provinces/[provinceSlug]/[contactSlug].tsx
+++ b/pages/provinces/[provinceSlug]/[contactSlug].tsx
@@ -8,7 +8,6 @@ import { ReportButton } from "~/components/report-button";
 import { getContactMeta } from "~/lib/meta";
 import { getContactsPaths } from "~/lib/province-utils";
 import provinces, { Contact } from "~/lib/provinces";
-import { getTheLastSegmentFromKebabCase } from "~/lib/string-utils";
 
 import { GetStaticPaths, GetStaticProps } from "next";
 import { NextSeo } from "next-seo";
@@ -74,10 +73,7 @@ export const getStaticProps: GetStaticProps = ({ params = {} }) => {
   const { provinceSlug, contactSlug } = params;
   const province = provinces.find((prov) => prov.slug === provinceSlug);
   const provinceName = province ? province.name : "";
-  const contactIndex = getTheLastSegmentFromKebabCase(contactSlug as string);
-  const contact = province
-    ? province.data[contactIndex as unknown as number]
-    : null;
+  const contact = province?.data.find((c) => c.slug === contactSlug);
   return {
     props: {
       provinceSlug,

--- a/pages/provinces/[provinceSlug]/index.tsx
+++ b/pages/provinces/[provinceSlug]/index.tsx
@@ -9,7 +9,8 @@ import { SeoText } from "~/components/seo-text";
 import { getCurrentLongDate } from "~/lib/date-utils";
 import { useSearch } from "~/lib/hooks/use-search";
 import { getProvinceMeta } from "~/lib/meta";
-import provinces, { Contact, getProvincesPaths } from "~/lib/provinces";
+import { getProvincesPaths } from "~/lib/province-utils";
+import provinces, { Contact } from "~/lib/provinces";
 
 import { GetStaticPaths, GetStaticProps } from "next";
 import { NextSeo } from "next-seo";


### PR DESCRIPTION
Closes #383
Closes  #289 because it's hard to write the tests without closing it

## Description

<!-- Describe your implementation plan and approach -->

## Current Tasks

<!-- List the tasks that you're planning to do in this PR.
This is to indicate how much you have been progressing before this PR is ready for review -->

- [x] renders the title and the breadcrumbs in ContactPage correctly
- [x] test getStaticPaths
- [x] remove the additional last segment from the contact slug
- [x] test getStaticProps
