### PR TITLE
fix(ui): fix incorrect text-size on form components

### DIFF
--- a/components/__tests__/search-filter.test.tsx
+++ b/components/__tests__/search-filter.test.tsx
@@ -47,7 +47,7 @@ describe("SearchFilter", () => {
             Kategori
           </label>
           <select
-            class="inline-block shadow-sm focus:ring-blue-500 focus:border-blue-500 w-full sm:text-sm border-gray-300 rounded-md"
+            class="inline-block shadow-sm focus:ring-blue-500 focus:border-blue-500 w-full text-sm border-gray-300 rounded-md"
             id="filter-kebutuhan"
             name="kebutuhan"
             title="Kategori"
@@ -122,7 +122,7 @@ describe("SearchFilter", () => {
             Kategori
           </label>
           <select
-            class="inline-block shadow-sm focus:ring-blue-500 focus:border-blue-500 w-full sm:text-sm border-gray-300 rounded-md"
+            class="inline-block shadow-sm focus:ring-blue-500 focus:border-blue-500 w-full text-sm border-gray-300 rounded-md"
             id="filter-kebutuhan"
             name="kebutuhan"
             title="Kategori"

--- a/components/__tests__/search-form.test.tsx
+++ b/components/__tests__/search-form.test.tsx
@@ -43,7 +43,7 @@ describe("SearchForm", () => {
               >
                 <input
                   autocomplete="off"
-                  class="first:rounded-l-md last:rounded-r-md focus:ring-blue-500 focus:border-blue-500 block w-full sm:text-sm border-gray-300 focus:z-10"
+                  class="first:rounded-l-md last:rounded-r-md focus:ring-blue-500 focus:border-blue-500 block w-full text-sm border-gray-300 focus:z-10"
                   id="keywordsInput"
                   type="text"
                   value=""

--- a/components/ui/forms/input-select.tsx
+++ b/components/ui/forms/input-select.tsx
@@ -11,7 +11,7 @@ export const InputSelect = React.forwardRef<HTMLSelectElement, SelectProps>(
     <select
       className={clsx(
         block ? "block" : "inline-block",
-        "shadow-sm focus:ring-blue-500 focus:border-blue-500 w-full sm:text-sm border-gray-300 rounded-md",
+        "shadow-sm focus:ring-blue-500 focus:border-blue-500 w-full text-sm border-gray-300 rounded-md",
         className,
       )}
       ref={ref}

--- a/components/ui/forms/input-text.tsx
+++ b/components/ui/forms/input-text.tsx
@@ -14,7 +14,7 @@ export const InputText = React.forwardRef<HTMLInputElement, InputTextProps>(
           isGroupItem
             ? "first:rounded-l-md last:rounded-r-md"
             : "shadow-sm rounded-md",
-          "focus:ring-blue-500 focus:border-blue-500 block w-full sm:text-sm border-gray-300",
+          "focus:ring-blue-500 focus:border-blue-500 block w-full text-sm border-gray-300",
           className,
         )}
         ref={ref}

--- a/components/ui/forms/input-textarea.tsx
+++ b/components/ui/forms/input-textarea.tsx
@@ -11,7 +11,7 @@ export const InputTextarea = React.forwardRef<
   return (
     <textarea
       className={clsx(
-        "shadow-sm focus:ring-blue-500 focus:border-blue-500 block w-full sm:text-sm border-gray-300 rounded-md",
+        "shadow-sm focus:ring-blue-500 focus:border-blue-500 block w-full text-sm border-gray-300 rounded-md",
         className,
       )}
       ref={ref}


### PR DESCRIPTION
## Description

On mobile devices, the default input text, select, and textarea font sizes make the form not have the same height as a button with size `md`. This fixes it.
