### PR TITLE
feat: latest news section implementation

### DIFF
--- a/components/contact-details.tsx
+++ b/components/contact-details.tsx
@@ -1,11 +1,10 @@
 import { CopyButton } from "~/components/copy-button";
 import { OpenMapButton } from "~/components/open-map-button";
-import { anchorTransformer } from "~/lib/htmr-transformers";
+import { htmrTransform } from "~/lib/htmr-transformers";
 import { Contact } from "~/lib/provinces";
 import { isNotEmpty, stripTags } from "~/lib/string-utils";
 
 import htmr from "htmr";
-import { HtmrOptions } from "htmr/src/types";
 
 type ContactDetailsProps = {
   contact: Contact;
@@ -35,9 +34,6 @@ type DescriptionItemProps = {
 
 const DescriptionItem = (props: DescriptionItemProps) => {
   const value = isNotEmpty(props.value) ? (props.value as string) : "";
-  const htmrTransform: HtmrOptions["transform"] = {
-    a: anchorTransformer,
-  };
 
   return (
     <div className="py-4 px-4 sm:py-5 sm:grid sm:grid-cols-3 sm:gap-4">

--- a/components/contact-list-item.tsx
+++ b/components/contact-list-item.tsx
@@ -1,6 +1,6 @@
-import React, { useMemo } from "react";
+import React from "react";
 
-import { anchorTransformer } from "~/lib/htmr-transformers";
+import { htmrTransform } from "~/lib/htmr-transformers";
 import { getContactMetaTitle } from "~/lib/meta";
 import { Contact } from "~/lib/provinces";
 import { isNotEmpty, stripTags } from "~/lib/string-utils";
@@ -15,7 +15,6 @@ import {
   PhoneIcon,
 } from "@heroicons/react/solid";
 import htmr from "htmr";
-import { HtmrOptions } from "htmr/src/types";
 import Link from "next/link";
 
 interface ContactListItemProps {
@@ -29,12 +28,6 @@ function ContactListItem({
   provinceName,
   provinceSlug,
 }: ContactListItemProps) {
-  const htmrTransform: HtmrOptions["transform"] = useMemo(
-    () => ({
-      a: anchorTransformer,
-    }),
-    [],
-  );
   return (
     <li>
       <div className="px-4 py-4 sm:px-6 relative hover:bg-gray-50">

--- a/components/home/__tests__/homepage-latest-news.test.tsx
+++ b/components/home/__tests__/homepage-latest-news.test.tsx
@@ -1,0 +1,13 @@
+import { HomePageLatestNews } from "../homepage-latest-news";
+
+import { render } from "@testing-library/react";
+
+describe("HomePageLatestNews", () => {
+  it("doesn't render more than 3 news items", () => {
+    const { container } = render(<HomePageLatestNews />);
+
+    const articles = container.querySelectorAll("article");
+
+    expect(articles.length).not.toBeGreaterThan(3);
+  });
+});

--- a/components/home/homepage-latest-news.tsx
+++ b/components/home/homepage-latest-news.tsx
@@ -1,3 +1,5 @@
+import { useMemo } from "react";
+
 import { latestNews } from "~/lib/home/latest-news";
 
 import { OutlineAnchorButton } from "../ui/button";
@@ -8,10 +10,20 @@ import { ExternalLinkIcon } from "@heroicons/react/outline";
 import htmr from "htmr";
 
 export function HomePageLatestNews() {
+  const sortedNews = useMemo(
+    () =>
+      latestNews
+        .slice(0, 3)
+        .sort(
+          (a, b) => b.attributes.date.getTime() - a.attributes.date.getTime(),
+        ),
+    [],
+  );
+
   return (
     <HomePageSection className="px-4 py-6 space-y-4">
       <h2 className="text-lg sm:text-xl font-semibold">Informasi Terbaru</h2>
-      {latestNews.slice(0, 3).map(({ attributes, html }) => (
+      {sortedNews.map(({ attributes, html }) => (
         <article
           key={attributes.date.toISOString()}
           className="border border-gray-200 rounded-md p-4 space-y-4"

--- a/components/home/homepage-latest-news.tsx
+++ b/components/home/homepage-latest-news.tsx
@@ -1,0 +1,51 @@
+import { latestNews } from "~/lib/home/latest-news";
+
+import { OutlineAnchorButton } from "../ui/button";
+
+import { HomePageSection } from "./homepage-section";
+
+import { ExternalLinkIcon } from "@heroicons/react/outline";
+import htmr from "htmr";
+
+export function HomePageLatestNews() {
+  return (
+    <HomePageSection className="px-4 py-6 space-y-4">
+      <h2 className="text-lg sm:text-xl font-semibold">Informasi Terbaru</h2>
+      {latestNews.map(({ attributes, html }) => (
+        <article
+          key={attributes.date.toISOString()}
+          className="border border-gray-200 rounded-md p-4 space-y-4"
+        >
+          <div className="space-y-2">
+            <div className="flex flex-row">
+              <h3 className="flex-1 text-base font-semibold text-gray-700 truncate">
+                {attributes.source}
+              </h3>
+              <span className="inline-block flex-none text-gray-400 ml-4">
+                {new Intl.DateTimeFormat("id-ID", {
+                  day: "numeric",
+                  month: "long",
+                  year: "numeric",
+                }).format(attributes.date)}
+              </span>
+            </div>
+            <div className="text-gray-600">{htmr(html)}</div>
+          </div>
+          {attributes.link && (
+            <OutlineAnchorButton
+              block
+              color="light-blue"
+              href={attributes.link}
+              icon={ExternalLinkIcon}
+              iconPosition="right"
+              rel="nofollow noopener noreferrer"
+              target="_blank"
+            >
+              {attributes.link_text}
+            </OutlineAnchorButton>
+          )}
+        </article>
+      ))}
+    </HomePageSection>
+  );
+}

--- a/components/home/homepage-latest-news.tsx
+++ b/components/home/homepage-latest-news.tsx
@@ -11,7 +11,7 @@ export function HomePageLatestNews() {
   return (
     <HomePageSection className="px-4 py-6 space-y-4">
       <h2 className="text-lg sm:text-xl font-semibold">Informasi Terbaru</h2>
-      {latestNews.map(({ attributes, html }) => (
+      {latestNews.slice(0, 3).map(({ attributes, html }) => (
         <article
           key={attributes.date.toISOString()}
           className="border border-gray-200 rounded-md p-4 space-y-4"

--- a/lib/home/latest-news.ts
+++ b/lib/home/latest-news.ts
@@ -1,0 +1,31 @@
+type LatestNewsItemAttributes = {
+  source: string;
+  date: Date;
+  description?: string;
+} & ({ link: string; link_text: string } | { link?: never });
+
+export interface LatestNewsItem {
+  attributes: LatestNewsItemAttributes;
+  html: string;
+}
+
+export const latestNews: LatestNewsItem[] = [
+  {
+    attributes: {
+      source: "Wilayah Jakarta",
+      date: new Date("2021-07-25T15:01:46Z"),
+      link: "https://sinergisehat.vaksin.siapdok.id/#/",
+      link_text: "Daftar vaksin SINERGI SEHAT",
+    },
+    html: "<p>Daftar Vaksin di Sentra Vaksinasi SINERGI SEHAT untuk masyarakat usia 12 tahun ke atas: Waktu Pelaksanaan: 22 Juli-15 September 2021 (Senin-Jumat pukul 08.30-15.00 WIB) Lokasi: The Media Hotel & Towers (Jln. Gunung Sahari No. 3, RT 16/RW 3, Gunung Sahari Utara).</p>",
+  },
+  {
+    attributes: {
+      source: "Kementerian Kesehatan",
+      date: new Date("2021-07-14T12:00:00Z"),
+      link: "https://yankes.kemkes.go.id/app/siranap/rumah_sakit?jenis=1&propinsi=31prop&kabkota=",
+      link_text: "Cek ketersediaan IGD Jakarta",
+    },
+    html: "<p>Kementerian Kesehatan meluncurkan SIRANAP terbaru versi 3.0. Melalui SIRANAP 3.0, kita dapat memeriksa ketersediaan IGD di seluruh Indonesia. Khusus untuk wilayah Jakarta ketersediaan IGD diperbarui setiap 3 jam sekali oleh para relawan lapangan.</p>",
+  },
+];

--- a/lib/htmr-transformers.tsx
+++ b/lib/htmr-transformers.tsx
@@ -1,8 +1,9 @@
 import { getKebabCase } from "./string-utils";
 
+import { HtmrOptions } from "htmr";
 import Link from "next/link";
 
-export const anchorTransformer = (node: JSX.IntrinsicElements["a"]) => {
+const a = (node: JSX.IntrinsicElements["a"]) => {
   const { href, children } = node;
 
   if (href) {
@@ -12,7 +13,7 @@ export const anchorTransformer = (node: JSX.IntrinsicElements["a"]) => {
         <a
           className="text-indigo-600 hover:text-indigo-500 relative"
           href={href}
-          rel="noopener noreferrer"
+          rel="nofollow noopener noreferrer"
           target="_blank"
         >
           {children}
@@ -34,39 +35,62 @@ export const anchorTransformer = (node: JSX.IntrinsicElements["a"]) => {
   );
 };
 
-// TODO: Unify these headings transformers into a single generic function
-export const heading1Transformer = (node: JSX.IntrinsicElements["h1"]) => {
+const h1 = (node: JSX.IntrinsicElements["h1"]) => {
   const { children } = node;
 
   return <h1 id={getKebabCase(children?.toString())}>{children}</h1>;
 };
 
-export const heading2Transformer = (node: JSX.IntrinsicElements["h2"]) => {
+const h2 = (node: JSX.IntrinsicElements["h2"]) => {
   const { children } = node;
 
   return <h2 id={getKebabCase(children?.toString())}>{children}</h2>;
 };
 
-export const heading3Transformer = (node: JSX.IntrinsicElements["h3"]) => {
+const h3 = (node: JSX.IntrinsicElements["h3"]) => {
   const { children } = node;
 
   return <h3 id={getKebabCase(children?.toString())}>{children}</h3>;
 };
 
-export const heading4Transformer = (node: JSX.IntrinsicElements["h4"]) => {
+const h4 = (node: JSX.IntrinsicElements["h4"]) => {
   const { children } = node;
 
   return <h4 id={getKebabCase(children?.toString())}>{children}</h4>;
 };
 
-export const heading5Transformer = (node: JSX.IntrinsicElements["h5"]) => {
+const h5 = (node: JSX.IntrinsicElements["h5"]) => {
   const { children } = node;
 
   return <h5 id={getKebabCase(children?.toString())}>{children}</h5>;
 };
 
-export const heading6Transformer = (node: JSX.IntrinsicElements["h6"]) => {
+const h6 = (node: JSX.IntrinsicElements["h6"]) => {
   const { children } = node;
 
   return <h6 id={getKebabCase(children?.toString())}>{children}</h6>;
+};
+
+const b = (node: JSX.IntrinsicElements["b"]) => {
+  const { children } = node;
+
+  return <b className="font-bold text-gray-900">{children}</b>;
+};
+
+const strong = (node: JSX.IntrinsicElements["strong"]) => {
+  const { children } = node;
+
+  return <strong className="font-bold text-gray-900">{children}</strong>;
+};
+
+export const htmrTransform: HtmrOptions["transform"] = {
+  h1,
+  h2,
+  h3,
+  h4,
+  h5,
+  h6,
+  a,
+  b,
+  strong,
 };

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -1,6 +1,7 @@
 import { HomePageContent } from "~/components/home/homepage-content";
 import { HomePageContributing } from "~/components/home/homepage-contributing";
 import { HomepageHeader } from "~/components/home/homepage-header";
+import { HomePageLatestNews } from "~/components/home/homepage-latest-news";
 import { HomePageSection } from "~/components/home/homepage-section";
 import { HomePageStart } from "~/components/home/homepage-start";
 import { HomePageWhatsAppCTA } from "~/components/home/homepage-whatsapp-cta";
@@ -8,32 +9,15 @@ import { Page } from "~/components/layout/page";
 import { Container } from "~/components/ui/container";
 import config from "~/lib/config";
 import { attributes, html } from "~/lib/home-page";
-import {
-  heading1Transformer,
-  heading2Transformer,
-  heading3Transformer,
-  heading4Transformer,
-  heading5Transformer,
-  heading6Transformer,
-} from "~/lib/htmr-transformers";
+import { htmrTransform } from "~/lib/htmr-transformers";
 
 import { ClockIcon } from "@heroicons/react/outline";
 import clsx from "clsx";
 import htmr from "htmr";
-import { HtmrOptions } from "htmr/src/types";
 import { NextSeo } from "next-seo";
 
 const meta = {
   title: `${config.site_tagline} | ${config.site_name}`,
-};
-
-const htmrTransform: HtmrOptions["transform"] = {
-  h1: heading1Transformer,
-  h2: heading2Transformer,
-  h3: heading3Transformer,
-  h4: heading4Transformer,
-  h5: heading5Transformer,
-  h6: heading6Transformer,
 };
 
 interface LastUpdatedAlertProps {
@@ -79,6 +63,7 @@ const HomePage = () => (
     <HomePageContent>
       <Container className="space-y-3">
         <HomePageStart />
+        <HomePageLatestNews />
         <HomePageContributing />
         <HomePageWhatsAppCTA />
         <LastUpdatedAlert />


### PR DESCRIPTION
Partial work for #324

## Description

Added latest news section implementation. Initially this will use dummy data, no Netlify CMS. But the shape of the interface already fits what was meant to be implemented on the Netlify CMS collection.

Will probably implement Netlify CMS on the same PR. cc: @zainfathoni

Design can already be reviewed. cc: @baraeb92 

![image](https://user-images.githubusercontent.com/5663877/127644962-8f9b44f6-155f-4cf5-bf9e-3ba03ec0db02.png)

## Current Tasks

<!-- List the tasks that you're planning to do in this PR.
This is to indicate how much you have been progressing before this PR is ready for review -->

- [x] Add initial latest news implementation (dummy data, no Netlify CMS)
- [ ] Add tests for latest news section
