### PR TITLE
Move `Buka Peta` button under `Salin` button

### DIFF
--- a/components/contact-details.tsx
+++ b/components/contact-details.tsx
@@ -41,15 +41,17 @@ const DescriptionItem = (props: DescriptionItemProps) => {
       <dd className="mt-1 flex text-sm text-gray-900 sm:mt-0 sm:col-span-2">
         <span className="flex-grow">
           {htmr(value, { transform: htmrTransform })}
+        </span>
+        <div className="flex flex-wrap justify-end space-y-1 content-start">
+          {typeof value == "string" &&
+            value.length > 0 &&
+            props.withCopyButton && <CopyButton text={stripTags(value)} />}
           {typeof value == "string" &&
             value.length > 0 &&
             props.withOpenMapButton && (
               <OpenMapButton address={stripTags(value)} />
             )}
-        </span>
-        {typeof value == "string" &&
-          value.length > 0 &&
-          props.withCopyButton && <CopyButton text={stripTags(value)} />}
+        </div>
       </dd>
     </div>
   );

--- a/components/contact-details.tsx
+++ b/components/contact-details.tsx
@@ -42,7 +42,7 @@ const DescriptionItem = (props: DescriptionItemProps) => {
         <span className="flex-grow">
           {htmr(value, { transform: htmrTransform })}
         </span>
-        <div className="flex flex-wrap justify-end space-y-1 content-start">
+        <div className="flex flex-col items-end space-y-1 flex-none ml-2">
           {typeof value == "string" &&
             value.length > 0 &&
             props.withCopyButton && <CopyButton text={stripTags(value)} />}


### PR DESCRIPTION
Closes #344  <!-- mention the issue that you're trying to close with this PR -->

## Description
Enclose `Buka Peta` button and `Salin` button inside a flex container with flex-wrap on.
<!-- Describe your implementation plan and approach -->
![Screenshot 2021-07-31 at 12 27 01 PM](https://user-images.githubusercontent.com/35729243/127728578-6b38549f-251d-46cc-a1e5-a2a73879531e.png)
![Screenshot 2021-07-31 at 12 26 48 PM](https://user-images.githubusercontent.com/35729243/127728582-e8242a5e-d1ad-4246-a302-fc43c48328ba.png)

## Current Tasks

<!-- List the tasks that you're planning to do in this PR.
This is to indicate how much you have been progressing before this PR is ready for review -->

- [x] Move `Buka Peta` button under `Salin` button


