### PR TITLE
fix(ui): adding little margin

### DIFF
--- a/pages/faq.tsx
+++ b/pages/faq.tsx
@@ -111,11 +111,11 @@ export default function FaqPage(props: FaqPageProps) {
                     <dt className="text-base font-semibold text-gray-900 md:col-span-5">
                       {question.pertanyaan}
                     </dt>
-                    <dd className="mt-2 md:mt-0 md:col-span-7">
+                    <dd className="space-y-4 mt-2 md:mt-0 md:col-span-7">
                       <p className="text-base text-gray-500">
                         {htmr(question.jawaban)}
                       </p>
-                      <small className="mt-4 inline-block">
+                      <small className="block">
                         Sumber:{" "}
                         {question.link ? (
                           <a

--- a/pages/faq.tsx
+++ b/pages/faq.tsx
@@ -115,7 +115,7 @@ export default function FaqPage(props: FaqPageProps) {
                       <p className="text-base text-gray-500">
                         {htmr(question.jawaban)}
                       </p>
-                      <small>
+                      <small className="mt-2 inline-block">
                         Sumber:{" "}
                         {question.link ? (
                           <a

--- a/pages/faq.tsx
+++ b/pages/faq.tsx
@@ -115,7 +115,7 @@ export default function FaqPage(props: FaqPageProps) {
                       <p className="text-base text-gray-500">
                         {htmr(question.jawaban)}
                       </p>
-                      <small className="mt-2 inline-block">
+                      <small className="mt-4 inline-block">
                         Sumber:{" "}
                         {question.link ? (
                           <a


### PR DESCRIPTION
Closes #522 
## Description

Adding `mt-2` to `<small>` tag. Seems a very little difference though.

**Before**
<img width="596" alt="image" src="https://user-images.githubusercontent.com/19145812/127739001-27aa4984-db95-4112-8d69-ca82f5a8915a.png">


**After**
<img width="591" alt="image" src="https://user-images.githubusercontent.com/19145812/127739008-679108ec-b967-454d-ac46-30dcc2fd6568.png">



