### PR TITLE
fix: use correct SEO title + improve a11y on Isolasi Mandiri page

### DIFF
--- a/components/layout/stacked-link.tsx
+++ b/components/layout/stacked-link.tsx
@@ -11,7 +11,10 @@ interface StackedListProps {
 }
 
 const LinkClasses = (i: number) => {
-  return [i > 0 ? "border-t" : undefined, "mx-2 py-4 flex justify-between"];
+  return [
+    i > 0 ? "border-t" : undefined,
+    "mx-2 py-4 flex justify-between relative",
+  ];
 };
 
 export default function StackedLink(list: StackedListProps) {
@@ -23,7 +26,11 @@ export default function StackedLink(list: StackedListProps) {
         <li key={i} className={clsx(LinkClasses(i))}>
           <p className="text-base text-gray-900 hover:text-gray-700">
             <Link href={link.url}>
-              <a data-testid={`next-link-${link.title}`} target="_blank">
+              <a
+                className="helper-link-cover"
+                data-testid={`next-link-${link.title}`}
+                target="_blank"
+              >
                 {link.title}
               </a>
             </Link>

--- a/components/layout/stacked-link.tsx
+++ b/components/layout/stacked-link.tsx
@@ -16,26 +16,27 @@ const LinkClasses = (i: number) => {
 
 export default function StackedLink(list: StackedListProps) {
   const { links } = list;
-  return (
-    <div>
-      {links.map((link, i) => (
-        <Link key={i} href={link.url}>
-          <a data-testid={`next-link-${link.title}`} target="_blank">
-            <div className={clsx(LinkClasses(i))}>
-              <div className="text-base text-gray-900 hover:text-gray-700">
-                {link.title}
-              </div>
 
-              <span className="text-brand-500 ml-4">
-                <ExternalLinkIcon
-                  className="h-6 w-6"
-                  data-testid={`external-link-icon-${link.title}`}
-                />
-              </span>
-            </div>
-          </a>
-        </Link>
+  return (
+    <ul>
+      {links.map((link, i) => (
+        <li key={i} className={clsx(LinkClasses(i))}>
+          <p className="text-base text-gray-900 hover:text-gray-700">
+            <Link href={link.url}>
+              <a data-testid={`next-link-${link.title}`} target="_blank">
+                {link.title}
+              </a>
+            </Link>
+          </p>
+
+          <div aria-hidden className="text-brand-500 ml-4">
+            <ExternalLinkIcon
+              className="h-6 w-6"
+              data-testid={`external-link-icon-${link.title}`}
+            />
+          </div>
+        </li>
       ))}
-    </div>
+    </ul>
   );
 }

--- a/pages/isolasi-mandiri.tsx
+++ b/pages/isolasi-mandiri.tsx
@@ -4,13 +4,12 @@ import { PageContent } from "~/components/layout/page-content";
 import { PageHeader } from "~/components/layout/page-header";
 import StackedLink from "~/components/layout/stacked-link";
 import isolasiMandiri, { IsolasiMandiri } from "~/lib/content/isolasi-mandiri";
-import siteConfig from "~/lib/content/site-config";
 
 import { GetStaticProps } from "next";
 import { NextSeo } from "next-seo";
 
 const meta = {
-  title: `Pedoman Isolasi Mandiri | ${siteConfig.site_name}`,
+  title: `Pedoman Isolasi Mandiri`,
 };
 
 type IsolasiMandiriPageProps = {
@@ -36,13 +35,11 @@ export default function IsolasiMandiriPage(props: IsolasiMandiriPageProps) {
         <PageContent>
           <div className="p-4 bg-white shadow overflow-hidden rounded-md space-y-8">
             {props.isolasiMandiri.categories.map((category, i: number) => (
-              <div key={i}>
-                <div className="text-base font-semibold text-gray-900 my-4">
+              <div key={i} className="space-y-4">
+                <h2 className="text-base font-semibold text-gray-900">
                   {category.title}
-                </div>
-                <div className="text-sm text-gray-500 mb-4">
-                  {category.description}
-                </div>
+                </h2>
+                <p className="text-sm text-gray-500">{category.description}</p>
                 <div className="p-2 bg-gray-50 rounded-md">
                   <StackedLink links={category.links} />
                 </div>

--- a/pages/isolasi-mandiri.tsx
+++ b/pages/isolasi-mandiri.tsx
@@ -10,6 +10,7 @@ import { NextSeo } from "next-seo";
 
 const meta = {
   title: `Pedoman Isolasi Mandiri`,
+  description: `Kumpulan informasi mengenai hal yang perlu Anda ketahui dan langkah penting yang perlu Anda lakukan untuk melakukan isolasi mandiri.`,
 };
 
 type IsolasiMandiriPageProps = {
@@ -20,7 +21,11 @@ export default function IsolasiMandiriPage(props: IsolasiMandiriPageProps) {
   return (
     <div>
       <Page>
-        <NextSeo openGraph={{ title: meta.title }} title={meta.title} />
+        <NextSeo
+          description={meta.description}
+          openGraph={{ title: meta.title, description: meta.description }}
+          title={meta.title}
+        />
         <PageHeader
           backButton={<BackButton href="/" />}
           breadcrumbs={[


### PR DESCRIPTION
## Description

### One.

Fixed the SEO title in Isolasi Mandiri page so the site name doesn't get duplicated. (by default the title template set by next-seo is `%s | site_name`)

**Before**

![image](https://user-images.githubusercontent.com/5663877/127762272-7a395343-5986-4938-821e-885d3f3bb360.png)

**After**

![image](https://user-images.githubusercontent.com/5663877/127762268-4ce1ca8f-2628-4cbd-8263-0c868c637e48.png)

### Two.

Improve accessibility on Isolasi Mandiri page + its stacked links by using proper semantic HTML elements instead of `div`.
