### PR TITLE
fix: use `h1` for page headers

### DIFF
--- a/components/layout/page-header.tsx
+++ b/components/layout/page-header.tsx
@@ -43,9 +43,9 @@ export function PageHeader({
           </div>
           <div className="mt-4 md:flex md:items-center md:justify-between">
             <div className="flex-1 min-w-0">
-              <h2 className="text-2xl font-bold leading-7 text-gray-900 sm:text-3xl sm:truncate">
+              <h1 className="text-2xl font-bold leading-7 text-gray-900 sm:text-3xl sm:truncate">
                 {title}
-              </h2>
+              </h1>
               {subtitle && (
                 <p className="flex items-center text-md text-gray-500">
                   {subtitle}


### PR DESCRIPTION
## Description

Improve page hierarchy by using `<h1>` for `PageHeader` title.
