### PR TITLE
perf(seo): change Twitter Card handle

### DIFF
--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -70,8 +70,8 @@ export default function App({ Component, pageProps, router }: AppProps) {
         title={siteConfig.site_tagline}
         titleTemplate={`%s | ${meta.siteName}`}
         twitter={{
-          handle: "@KawalCOVID19",
-          site: "@KawalCOVID19",
+          handle: "@WargaBantuWarga",
+          site: "@WargaBantuWarga",
           cardType: "summary_large_image",
         }}
       />


### PR DESCRIPTION
## Description

WBW now has an official Twitter handle, so we change the Twitter Card's `handle` setting to that.
