### PR TITLE
fix: change sembako URL back to `sembako.wargabantuwarga.com`

### DIFF
--- a/components/home/__tests__/homepage-start.test.tsx
+++ b/components/home/__tests__/homepage-start.test.tsx
@@ -223,7 +223,7 @@ describe("HomePageStart", () => {
           class="px-4 py-6"
         >
           <a
-            href="https://petakebaikan.kitabisa.com"
+            href="https://sembako.wargabantuwarga.com"
             rel="nofollow noopener noreferrer"
             target="_blank"
           >

--- a/constants/index.ts
+++ b/constants/index.ts
@@ -1,2 +1,2 @@
 export const PUBLIC_PATH = "https://www.wargabantuwarga.com";
-export const HOMEPAGE_START_CTA_URL = "https://petakebaikan.kitabisa.com";
+export const HOMEPAGE_START_CTA_URL = "https://sembako.wargabantuwarga.com";


### PR DESCRIPTION
Closes #548

## Description

Reverts the Sembako CTA URL back to `sembako.wargabantuwarga.com`
