### PR TITLE
chore(kodiak): auto-merge deps updates from dependabot

### DIFF
--- a/.kodiak.toml
+++ b/.kodiak.toml
@@ -1,1 +1,8 @@
 version = 1
+
+[update]
+ignored_usernames = ["dependabot"]
+
+[merge.automerge_dependencies]
+versions = ["minor", "patch"]
+usernames = ["dependabot"]


### PR DESCRIPTION
## Description

Allow Kodiak bot to auto-merge dependencies updates from Dependabot without approval. Only minor and patch updates are automatically merged, major deps upgrades still need our manual approval.
