### PR TITLE
perf(ui): improve bottom navigation ui by minimize the icon size

### DIFF
--- a/components/layout/__tests__/navigation.test.tsx
+++ b/components/layout/__tests__/navigation.test.tsx
@@ -20,7 +20,7 @@ describe("Navigation", () => {
             class="flex items-center justify-evenly w-full"
           >
             <li
-              class="relative"
+              class="relative p-4"
             >
               <a
                 class="inline-flex flex-col items-center justify-center text-center h-12 px-2 rounded-md text-gray-600 hover:text-blue-600"
@@ -28,7 +28,7 @@ describe("Navigation", () => {
               >
                 <svg
                   aria-hidden="true"
-                  class="w-8 h-8"
+                  class="w-6 h-6 mb-1"
                   fill="none"
                   stroke="currentColor"
                   viewBox="0 0 24 24"
@@ -49,7 +49,7 @@ describe("Navigation", () => {
               </a>
             </li>
             <li
-              class="relative"
+              class="relative p-4"
             >
               <a
                 class="inline-flex flex-col items-center justify-center text-center h-12 px-2 rounded-md text-gray-600 hover:text-blue-600"
@@ -59,7 +59,7 @@ describe("Navigation", () => {
               >
                 <svg
                   aria-hidden="true"
-                  class="w-8 h-8"
+                  class="w-6 h-6 mb-1"
                   fill="none"
                   stroke="currentColor"
                   viewBox="0 0 24 24"
@@ -80,7 +80,7 @@ describe("Navigation", () => {
               </a>
             </li>
             <li
-              class="relative"
+              class="relative p-4"
             >
               <a
                 class="inline-flex flex-col items-center justify-center text-center h-12 px-2 rounded-md text-gray-600 hover:text-blue-600"
@@ -88,7 +88,7 @@ describe("Navigation", () => {
               >
                 <svg
                   aria-hidden="true"
-                  class="w-8 h-8"
+                  class="w-6 h-6 mb-1"
                   fill="none"
                   stroke="currentColor"
                   viewBox="0 0 24 24"
@@ -109,7 +109,7 @@ describe("Navigation", () => {
               </a>
             </li>
             <li
-              class="relative"
+              class="relative p-4"
             >
               <a
                 class="inline-flex flex-col items-center justify-center text-center h-12 px-2 rounded-md text-gray-600 hover:text-blue-600"
@@ -117,7 +117,7 @@ describe("Navigation", () => {
               >
                 <svg
                   aria-hidden="true"
-                  class="w-8 h-8"
+                  class="w-6 h-6 mb-1"
                   fill="none"
                   stroke="currentColor"
                   viewBox="0 0 24 24"

--- a/components/layout/navigation.tsx
+++ b/components/layout/navigation.tsx
@@ -20,7 +20,7 @@ export function Navigation() {
     return (
       <>
         {createElement(item.icon, {
-          className: "w-8 h-8",
+          className: "w-6 h-6 mb-1",
           "aria-hidden": true,
         })}
         <span className="text-xs truncate">{item.name}</span>
@@ -38,7 +38,7 @@ export function Navigation() {
               : router.asPath.startsWith(item.href);
 
             return (
-              <li key={item.name} className="relative">
+              <li key={item.name} className="relative p-4">
                 {item.external ? (
                   <a
                     className={clsx(...navigationClasses(isActive))}


### PR DESCRIPTION
Closes <!-- mention the issue that you're trying to close with this PR -->

## Description
I reduced the icon size by 0.5rem to improve the UI and make it more clean because I think previous size is too big. 

Before
![Screenshot_2021-08-09_20-07-39](https://user-images.githubusercontent.com/69680330/128715557-ac60d370-6107-46f6-8e7e-20f471088f62.png)
After
![Screenshot_2021-08-09_20-07-55](https://user-images.githubusercontent.com/69680330/128715572-375df6e3-f9b0-4abf-80e5-9903969b6308.png)

Dont worry I already tested it
![Screenshot_2021-08-09_20-06-13](https://user-images.githubusercontent.com/69680330/128716283-420508f5-9d05-4944-9562-bd653345de33.png)



<!-- Describe your implementation plan and approach -->

## Current Tasks

<!-- List the tasks that you're planning to do in this PR.
This is to indicate how much you have been progressing before this PR is ready for review -->

- [ ] 
- [ ] 
- [ ] 
