### PR TITLE
perf(security): added `Permissions-Policy` header

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -11,6 +11,7 @@
     X-XSS-Protection = "1; mode=block"
     X-Content-Type-Options = "nosniff"
     Referrer-Policy = "same-origin"
+    Permissions-Policy = "camera=(), microphone=(), geolocation=(), interest-cohort=()"
 
 [[plugins]]
   package = "@netlify/plugin-nextjs"

--- a/next.config.js
+++ b/next.config.js
@@ -12,6 +12,12 @@ const securityHeaders = [
     key: "X-Content-Type-Options",
     value: "nosniff",
   },
+  // Disables camera, microphone, and geolocation.
+  // `interest-cohort=()` opts the website out of Google's FLoC: https://amifloced.org/
+  {
+    key: "Permissions-Policy",
+    value: "camera=(), microphone=(), geolocation=(), interest-cohort=()",
+  },
 ];
 
 /** @type {import("next/dist/next-server/server/config-shared").NextConfig} */


### PR DESCRIPTION
Closes #610

## Description

Added a `Permissions-Policy` header to control which features and APIs can be used in the browser.

## Current Tasks

<!-- (Optional) List the tasks that you're planning to do in this PR.
This is to indicate how much you have been progressing before this PR is ready for review -->

- [x] Add `Permissions-Policy` header
- [x] Test on deploy preview (manually) that the headers are loaded correctly
