### PR TITLE
security: Add Content-Security-Policy

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -11,7 +11,7 @@
     X-XSS-Protection = "1; mode=block"
     X-Content-Type-Options = "nosniff"
     Referrer-Policy = "same-origin"
-    Content-Security-Policy = "default-src 'self'; style-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-inline' *.googletagmanager.com; img-src 'self' blob: data: https:; "
+    Content-Security-Policy = "default-src 'self'; style-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-inline' *.googletagmanager.com; img-src 'self' blob: data: https:; frame-ancestors 'none'; "
 
 [[plugins]]
   package = "@netlify/plugin-nextjs"

--- a/netlify.toml
+++ b/netlify.toml
@@ -11,6 +11,7 @@
     X-XSS-Protection = "1; mode=block"
     X-Content-Type-Options = "nosniff"
     Referrer-Policy = "same-origin"
+    Content-Security-Policy = "default-src 'self'; style-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-inline' *.googletagmanager.com; img-src 'self' blob: data: https:; "
 
 [[plugins]]
   package = "@netlify/plugin-nextjs"

--- a/next.config.js
+++ b/next.config.js
@@ -2,8 +2,6 @@ const withBundleAnalyzer = require("@next/bundle-analyzer")({
   enabled: process.env.ANALYZE === "true",
 });
 
-/** @type {import("next/dist/lib/config-shared").Header['headers']} */
-
 const ContentSecurityPolicy = `
   default-src 'self';
   script-src 'self' 'unsafe-inline' *.googletagmanager.com 'unsafe-eval';
@@ -12,6 +10,7 @@ const ContentSecurityPolicy = `
   frame-ancestors 'none';
 `;
 
+/** @type {import("next/dist/lib/config-shared").Header['headers']} */
 const securityHeaders = [
   {
     key: "Content-Security-Policy",

--- a/next.config.js
+++ b/next.config.js
@@ -6,9 +6,9 @@ const withBundleAnalyzer = require("@next/bundle-analyzer")({
 
 const ContentSecurityPolicy = `
   default-src 'self';
-  script-src 'self' 'unsafe-eval' 'unsafe-inline' *.googletagmanager.com;
+  script-src 'self' 'unsafe-inline' *.googletagmanager.com;
   style-src 'self' 'unsafe-inline';
-  img-src * blob: data: https:;
+  img-src 'self' blob: data: https:;
 `;
 
 const securityHeaders = [

--- a/next.config.js
+++ b/next.config.js
@@ -6,9 +6,10 @@ const withBundleAnalyzer = require("@next/bundle-analyzer")({
 
 const ContentSecurityPolicy = `
   default-src 'self';
-  script-src 'self' 'unsafe-inline' *.googletagmanager.com;
+  script-src 'self' 'unsafe-inline' *.googletagmanager.com 'unsafe-eval';
   style-src 'self' 'unsafe-inline';
   img-src 'self' blob: data: https:;
+  frame-ancestors 'none';
 `;
 
 const securityHeaders = [

--- a/next.config.js
+++ b/next.config.js
@@ -3,7 +3,19 @@ const withBundleAnalyzer = require("@next/bundle-analyzer")({
 });
 
 /** @type {import("next/dist/lib/config-shared").Header['headers']} */
+
+const ContentSecurityPolicy = `
+  default-src 'self';
+  script-src 'self' 'unsafe-eval' 'unsafe-inline' *.googletagmanager.com;
+  style-src 'self' 'unsafe-inline';
+  img-src * blob: data: https:;
+`;
+
 const securityHeaders = [
+  {
+    key: "Content-Security-Policy",
+    value: ContentSecurityPolicy.replace(/\n/g, ""),
+  },
   {
     key: "X-Frame-Options",
     value: "DENY",
@@ -11,10 +23,6 @@ const securityHeaders = [
   {
     key: "X-Content-Type-Options",
     value: "nosniff",
-  },
-  {
-    key: "defaultSrc",
-    valueL: "'self'",
   },
 ];
 

--- a/next.config.js
+++ b/next.config.js
@@ -12,6 +12,10 @@ const securityHeaders = [
     key: "X-Content-Type-Options",
     value: "nosniff",
   },
+  {
+    key: "defaultSrc",
+    valueL: "'self'",
+  },
 ];
 
 /** @type {import("next/dist/next-server/server/config-shared").NextConfig} */


### PR DESCRIPTION
Closes #611 
## Description

Added a `Content-Security-Policy` header to prevent cross-site scripting (XSS).

## Current Tasks


 * [X]  Define which resources need to be added into the allowlist

 - defaultSrc : self
 - styleSrc : unsafe-inline
 - scriptSrc : self, .googletagmanager.com
 - imgSrc : self, https:, data: 

for `unsave-eval` on `scriptSrc`, we need to check if it's production or not. 
because in development webpack use unsave-eval.


* [X]  Add the CSP header into `headers` key on `next.config.js`
* [X]  Add the CSP header into `headers` key on `netlify.toml`

