### PR TITLE
docs: add gitbook as supporter

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,12 @@ You can check out [the Next.js GitHub repository](https://github.com/vercel/next
 - [Tailwind CSS](https://tailwindcss.com/)
 - [Tailwind UI](https://tailwindui.com/)
 
+## Supporter
+
+Special thanks goes to our supporter.
+
+<p align="center"><a href="https://www.gitbook.com/" target="_blank" rel="noopener noreferrer"><img width="300" src="https://user-images.githubusercontent.com/56619123/128886904-5887e9e2-e444-4db5-81f8-5cd33a3d79ad.png" alt="GitBook Logo"></a></p>
+
 ## Contributing
 
 See our contribution guidelines in these languages:


### PR DESCRIPTION
Closes #632 

## Description

Added GitBook as supporter into README.md file. I put it above **Contributing** section. The result is going to look like this:

## Supporter

Special thanks goes to our supporter.

<p align="center"><a href="https://www.gitbook.com/" target="_blank" rel="noopener noreferrer"><img width="300" src="https://user-images.githubusercontent.com/56619123/128886904-5887e9e2-e444-4db5-81f8-5cd33a3d79ad.png" alt="GitBook Logo"></a></p>
