### PR TITLE
fix: revert back to mirror box

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "lint": "eslint \"**/*.{js,jsx,ts,tsx}\"",
     "lint:fix": "eslint --fix \"**/*.{js,jsx,ts,tsx}\"",
     "mirror-box": "ts-node etc/mirror-box.ts",
-    "netlify-export": "yarn fetch-wbw && yarn build && next export",
+    "netlify-export": "yarn mirror-box && yarn build && next export",
     "prepare": "husky install",
     "start": "next start",
     "cypress:open": "cypress open",


### PR DESCRIPTION
## Description

This pull request reverts back to deployment script from `fetch-wbw` to `mirror-box` caused by #606 