### PR TITLE
fix: display filtered `kebutuhan` contacts count on province-list

### DIFF
--- a/__tests__/pages/provinces/index.test.tsx
+++ b/__tests__/pages/provinces/index.test.tsx
@@ -109,6 +109,15 @@ describe("getStaticProps", () => {
       name,
       slug,
       count: data.length,
+      ambulansCount: data.filter((contact) => contact.kebutuhan === "Ambulans")
+        .length,
+      rsCount: data.filter((contact) => contact.kebutuhan === "Rumah sakit")
+        .length,
+      donorPlasmaCount: data.filter(
+        (contact) => contact.kebutuhan === "Donor plasma",
+      ).length,
+      oksigenCount: data.filter((contact) => contact.kebutuhan === "Oksigen")
+        .length,
     }));
     expect(getStaticProps({})).toEqual({
       props: {

--- a/__tests__/pages/provinces/index.test.tsx
+++ b/__tests__/pages/provinces/index.test.tsx
@@ -58,44 +58,25 @@ describe("ProvincesPage", () => {
     ).toBeVisible();
   });
 
-  it("renders the provinces list kebutuhan entry count correctly", async () => {
-    const checkRenderKebutuhanEntryCount = async (
-      kebutuhan: string,
-      entryCount: number,
-    ) => {
+  it.each`
+    kebutuhan           | count
+    ${"Ambulans"}       | ${provinceListItem.ambulansCount}
+    ${"Rumah%20sakit"}  | ${provinceListItem.rsCount}
+    ${"Oksigen"}        | ${provinceListItem.oksigenCount}
+    ${"Donor%20plasma"} | ${provinceListItem.donorPlasmaCount}
+  `(
+    "renders the entry count of kebutuhan $kebutuhan in province list correctly",
+    async ({ kebutuhan, count }) => {
       await router.push(`/provinces?kebutuhan=${kebutuhan}`);
-      const { unmount } = render(
-        <ProvincesPage provincesList={provinceList} />,
-      );
+      render(<ProvincesPage provincesList={provinceList} />);
 
       const provinceLink = screen.getByRole("link", {
         name: /informasi faskes & alkes untuk covid-19 di provinsi/i,
       });
 
-      expect(
-        within(provinceLink).getByText(`${entryCount} Entri`),
-      ).toBeVisible();
-
-      unmount();
-    };
-
-    await checkRenderKebutuhanEntryCount(
-      "Ambulans",
-      provinceListItem.ambulansCount,
-    );
-    await checkRenderKebutuhanEntryCount(
-      "Rumah%20sakit",
-      provinceListItem.rsCount,
-    );
-    await checkRenderKebutuhanEntryCount(
-      "Oksigen",
-      provinceListItem.oksigenCount,
-    );
-    await checkRenderKebutuhanEntryCount(
-      "Donor%20plasma",
-      provinceListItem.donorPlasmaCount,
-    );
-  });
+      expect(within(provinceLink).getByText(`${count} Entri`)).toBeVisible();
+    },
+  );
 
   it("renders the SEO text correctly", () => {
     const { date, monthStr } = dateMockBuilder();

--- a/__tests__/pages/provinces/index.test.tsx
+++ b/__tests__/pages/provinces/index.test.tsx
@@ -7,6 +7,7 @@ import {
   within,
 } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
+import router from "next/router";
 import { provinceListItemBuilder } from "~/components/__mocks__/builders/province-list";
 import { dateMockBuilder } from "~/lib/__mocks__/builders/date-mock";
 import provinces from "~/lib/data/provinces";
@@ -55,6 +56,45 @@ describe("ProvincesPage", () => {
     expect(
       within(provinceLink).getByText(`${provinceListItem.count} Entri`),
     ).toBeVisible();
+  });
+
+  it("renders the provinces list kebutuhan entry count correctly", async () => {
+    const checkRenderKebutuhanEntryCount = async (
+      kebutuhan: string,
+      entryCount: number,
+    ) => {
+      await router.push(`/provinces?kebutuhan=${kebutuhan}`);
+      const { unmount } = render(
+        <ProvincesPage provincesList={provinceList} />,
+      );
+
+      const provinceLink = screen.getByRole("link", {
+        name: /informasi faskes & alkes untuk covid-19 di provinsi/i,
+      });
+
+      expect(
+        within(provinceLink).getByText(`${entryCount} Entri`),
+      ).toBeVisible();
+
+      unmount();
+    };
+
+    await checkRenderKebutuhanEntryCount(
+      "Ambulans",
+      provinceListItem.ambulansCount,
+    );
+    await checkRenderKebutuhanEntryCount(
+      "Rumah%20sakit",
+      provinceListItem.rsCount,
+    );
+    await checkRenderKebutuhanEntryCount(
+      "Oksigen",
+      provinceListItem.oksigenCount,
+    );
+    await checkRenderKebutuhanEntryCount(
+      "Donor%20plasma",
+      provinceListItem.donorPlasmaCount,
+    );
   });
 
   it("renders the SEO text correctly", () => {

--- a/components/__mocks__/builders/province-list.tsx
+++ b/components/__mocks__/builders/province-list.tsx
@@ -7,5 +7,9 @@ export const provinceListItemBuilder = build<ProvinceListItem>({
     initials: fake((f) => f.address.stateAbbr()),
     slug: fake((f) => f.lorem.slug()),
     count: fake((f) => f.random.number({ min: 1, max: 100 })),
+    ambulansCount: fake((f) => f.random.number({ min: 1, max: 100 })),
+    rsCount: fake((f) => f.random.number({ min: 1, max: 100 })),
+    donorPlasmaCount: fake((f) => f.random.number({ min: 1, max: 100 })),
+    oksigenCount: fake((f) => f.random.number({ min: 1, max: 100 })),
   },
 });

--- a/components/province-list.tsx
+++ b/components/province-list.tsx
@@ -11,10 +11,36 @@ export type ProvinceListItem = {
   name: string;
   slug: string;
   count: number;
+  ambulansCount: number;
+  rsCount: number;
+  donorPlasmaCount: number;
+  oksigenCount: number;
 };
 
 type ProvinceListProps = {
   data: ProvinceListItem[];
+};
+
+const getProvinceContactsCount = (
+  province: ProvinceListItem,
+  kebutuhan?: string[] | string,
+) => {
+  if (typeof kebutuhan === "string") {
+    switch (kebutuhan) {
+      case "Ambulans":
+        return province.ambulansCount;
+      case "Oksigen":
+        return province.oksigenCount;
+      case "Donor plasma":
+        return province.donorPlasmaCount;
+      case "Rumah sakit":
+        return province.rsCount;
+      default:
+        return province.count;
+    }
+  }
+
+  return province.count;
 };
 
 export function ProvinceList(props: ProvinceListProps) {
@@ -24,6 +50,8 @@ export function ProvinceList(props: ProvinceListProps) {
     () => (router.query.kebutuhan as string) || undefined,
     [router.query],
   );
+
+  const kebutuhan = router.query.kebutuhan;
 
   if (props.data.length > 0) {
     return (
@@ -52,7 +80,9 @@ export function ProvinceList(props: ProvinceListProps) {
                   <span className="text-gray-900 font-semibold hover:text-gray-600">
                     {province.name}
                   </span>
-                  <p className="text-gray-500">{province.count} Entri</p>
+                  <p className="text-gray-500">
+                    {getProvinceContactsCount(province, kebutuhan)} Entri
+                  </p>
                 </div>
               </a>
             </Link>

--- a/components/province-list.tsx
+++ b/components/province-list.tsx
@@ -25,22 +25,18 @@ const getProvinceContactsCount = (
   province: ProvinceListItem,
   kebutuhan?: string[] | string,
 ) => {
-  if (typeof kebutuhan === "string") {
-    switch (kebutuhan) {
-      case "Ambulans":
-        return province.ambulansCount;
-      case "Oksigen":
-        return province.oksigenCount;
-      case "Donor plasma":
-        return province.donorPlasmaCount;
-      case "Rumah sakit":
-        return province.rsCount;
-      default:
-        return province.count;
-    }
+  switch (kebutuhan) {
+    case "Ambulans":
+      return province.ambulansCount;
+    case "Oksigen":
+      return province.oksigenCount;
+    case "Donor plasma":
+      return province.donorPlasmaCount;
+    case "Rumah sakit":
+      return province.rsCount;
+    default:
+      return province.count;
   }
-
-  return province.count;
 };
 
 export function ProvinceList(props: ProvinceListProps) {

--- a/lib/data/helpers/provinces.ts
+++ b/lib/data/helpers/provinces.ts
@@ -30,3 +30,10 @@ export const getContactsPaths = (provinces: Provinces): ContactPath[] => {
   });
   return contactsPaths;
 };
+
+export const getProvinceKebutuhanContactsCount = (
+  contacts: Contact[],
+  kebutuhan: string,
+): number => {
+  return contacts.filter((contact) => contact.kebutuhan === kebutuhan).length;
+};

--- a/pages/provinces/index.tsx
+++ b/pages/provinces/index.tsx
@@ -8,7 +8,7 @@ import { LinksWell } from "~/components/links-well";
 import { ProvinceList, ProvinceListItem } from "~/components/province-list";
 import { SearchForm } from "~/components/search-form";
 import { SeoText } from "~/components/seo-text";
-import provinces from "~/lib/data/provinces";
+import provinces, { Contact } from "~/lib/data/provinces";
 import { getCurrentMonthAndYear } from "~/lib/date-utils";
 import { useSearch } from "~/lib/hooks/use-search";
 import { getInitial } from "~/lib/string-utils";
@@ -108,12 +108,23 @@ export default function ProvincesPage(props: ProvincesPageProps) {
   );
 }
 
+const getProvinceKebutuhanContactsCount = (
+  contacts: Contact[],
+  kebutuhan: string,
+) => {
+  return contacts.filter((contact) => contact.kebutuhan === kebutuhan).length;
+};
+
 export const getStaticProps: GetStaticProps = () => {
   const provincesList = provinces.map(({ name, slug, data }) => ({
     initials: getInitial(name),
     name,
     slug,
     count: data.length,
+    ambulansCount: getProvinceKebutuhanContactsCount(data, "Ambulans"),
+    rsCount: getProvinceKebutuhanContactsCount(data, "Rumah sakit"),
+    donorPlasmaCount: getProvinceKebutuhanContactsCount(data, "Donor plasma"),
+    oksigenCount: getProvinceKebutuhanContactsCount(data, "Oksigen"),
   }));
 
   return {

--- a/pages/provinces/index.tsx
+++ b/pages/provinces/index.tsx
@@ -8,10 +8,11 @@ import { LinksWell } from "~/components/links-well";
 import { ProvinceList, ProvinceListItem } from "~/components/province-list";
 import { SearchForm } from "~/components/search-form";
 import { SeoText } from "~/components/seo-text";
-import provinces, { Contact } from "~/lib/data/provinces";
+import provinces from "~/lib/data/provinces";
 import { getCurrentMonthAndYear } from "~/lib/date-utils";
 import { useSearch } from "~/lib/hooks/use-search";
 import { getInitial } from "~/lib/string-utils";
+import { getProvinceKebutuhanContactsCount } from "~/lib/data/helpers/provinces";
 
 type ProvincesPageProps = {
   provincesList: ProvinceListItem[];
@@ -107,13 +108,6 @@ export default function ProvincesPage(props: ProvincesPageProps) {
     </Page>
   );
 }
-
-const getProvinceKebutuhanContactsCount = (
-  contacts: Contact[],
-  kebutuhan: string,
-) => {
-  return contacts.filter((contact) => contact.kebutuhan === kebutuhan).length;
-};
 
 export const getStaticProps: GetStaticProps = () => {
   const provincesList = provinces.map(({ name, slug, data }) => ({


### PR DESCRIPTION
Closes #581 <!-- mention the issue that you're trying to close with this PR -->

## Description

Fixed the issue of Province List displaying the total count of all contacts instead of the contacts of a specific `kebutuhan`. I added new fields in `provinces` props that count only contacts of a specific `kebutuhan`.
<!-- Describe your implementation plan and approach -->
![Screenshot 2021-08-12 at 8 52 40 PM](https://user-images.githubusercontent.com/35729243/129202934-23e5e926-d37f-472d-97bc-d3ed30d633d0.png)

## Current Tasks

<!-- (Optional) List the tasks that you're planning to do in this PR.
This is to indicate how much you have been progressing before this PR is ready for review -->

- [x] Fix Total count showing a wrong number when query param `kebutuhan` exist
