### PR TITLE
fix: overflow alamat

### DIFF
--- a/etc/fetchers/__tests__/utils.test.ts
+++ b/etc/fetchers/__tests__/utils.test.ts
@@ -106,7 +106,7 @@ describe("utils > contactReducer", () => {
     "jakarta timur",
     "RS WargaBantuWarga.com",
     "(0123) 456789",
-    "Jl. Palsu, No. 9",
+    '<div class="alamat">Jl. Palsu, No. 9</div>',
     "",
     "",
     "19/7/2021",
@@ -154,5 +154,17 @@ describe("utils > contactReducer", () => {
     expect(result.terakhir_update).toBe("19/7/2021");
     expect(result).toHaveProperty("verifikasi");
     expect(result.verifikasi).toBe(1);
+  });
+
+  it("should remove html tag from alamat", () => {
+    const obj: Record<string, number | string> = {};
+    const col: SheetColumn = {
+      name: "alamat",
+      index: 6,
+    };
+
+    const result = reducer(obj, col);
+
+    expect(result.alamat).toBe("Jl. Palsu, No. 9");
   });
 });

--- a/etc/fetchers/utils.ts
+++ b/etc/fetchers/utils.ts
@@ -61,6 +61,8 @@ export const contactReducer = (row: string[]) => {
       cellValue = extractGoogleQuery(cellValue);
     } else if (colName == "ketersediaan") {
       cellValue = toTitleCase(cellValue);
+    } else if (colName == "alamat") {
+      cellValue = stripTags(cellValue);
     }
     prev[colName] = cellValue;
     if (colName == "kontak") {


### PR DESCRIPTION
Closes #613 

## Description

Fixed the issue of overflow alamat, root cause of this problem is data alamat from source data have html tag.

note: don't forget to re-run `yarn fetch-wbw` to renew data 

### Before
<img width="509" alt="Screen Shot 2021-08-13 at 07 59 58" src="https://user-images.githubusercontent.com/10627998/129288785-3fdd09ef-2fd7-4017-afe6-050b55da9cb0.png">

### After
<img width="730" alt="Screen Shot 2021-08-13 at 08 00 45" src="https://user-images.githubusercontent.com/10627998/129288803-a5223357-4304-4deb-bbc2-75250b048360.png">

## Current Tasks

- [x] (fix address overflow)
