### PR TITLE
fix: make NavigationMenuPopover scrollable and not override Navigation

### DIFF
--- a/components/layout/__tests__/navigation.test.tsx
+++ b/components/layout/__tests__/navigation.test.tsx
@@ -11,7 +11,7 @@ describe("Navigation", () => {
 
     expect(container.firstChild).toMatchInlineSnapshot(`
 <nav
-  class="flex items-center justify-center fixed bottom-0 w-full h-16 px-2 bg-white border-t border-gray-300 z-30"
+  class="flex items-center justify-center fixed bottom-0 w-full h-16 px-2 bg-white border-t border-gray-300 z-40"
 >
   <div
     class="flex items-center justify-center w-full max-w-xl mx-auto"

--- a/components/layout/navigation-menu.tsx
+++ b/components/layout/navigation-menu.tsx
@@ -55,7 +55,7 @@ export function NavigationMenuPopover({
       className="fixed top-16 bottom-16 left-1/2 transform -translate-x-1/2 w-full max-w-xl z-10"
       unmount
     >
-      <nav className="flex flex-col w-full h-full flex-1 p-2 bg-white text-gray-900">
+      <nav className="flex flex-col w-full h-full flex-1 p-2 bg-white text-gray-900 overflow-auto">
         <ul className="space-y-2">
           {navMenu.map((item) => {
             const isActive = item.exact

--- a/components/layout/navigation.tsx
+++ b/components/layout/navigation.tsx
@@ -29,7 +29,7 @@ export function Navigation() {
   };
 
   return (
-    <nav className="flex items-center justify-center fixed bottom-0 w-full h-16 px-2 bg-white border-t border-gray-300 z-30">
+    <nav className="flex items-center justify-center fixed bottom-0 w-full h-16 px-2 bg-white border-t border-gray-300 z-40">
       <div className="flex items-center justify-center w-full max-w-xl mx-auto">
         <ul className="flex items-center justify-evenly w-full">
           {bottomNavigation.map((item) => {


### PR DESCRIPTION
Closes #723 

## Description

I add some tailwind classes to `NavigationMenuPopover` component and `Navigation` component. Basically, I add `overflow-auto` to make NavigationMenu scrollable and then add `z-40` to make `Navigation` component to front.