### PR TITLE
fix: tweak logos section in the about us page

### DIFF
--- a/next-env.d.ts
+++ b/next-env.d.ts
@@ -1,6 +1,3 @@
 /// <reference types="next" />
 /// <reference types="next/types/global" />
 /// <reference types="next/image-types/global" />
-
-// NOTE: This file should not be edited
-// see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/pages/tentang-kami.tsx
+++ b/pages/tentang-kami.tsx
@@ -115,13 +115,13 @@ export default function AboutPage() {
             <h2 className="text-center font-semibold text-gray-700 text-lg">
               Terima kasih kepada para kolaborator inisiatif #WargaBantuWarga
             </h2>
-            <div className="flex flex-wrap justify-center items-center space-x-4 space-y-4 relative">
+            <div className="flex flex-wrap justify-center items-center relative">
               {collaboratorsData.collaborators.map(
                 (collaborator: Collaborator) => {
                   return (
                     <a
                       key={collaborator.link_url}
-                      className="flex justify-center items-center relative h-16 w-24"
+                      className="flex justify-center items-center relative h-16 w-24 m-1"
                       href={collaborator.link_url}
                       rel="nofollow noopener noreferrer"
                       target="_blank"


### PR DESCRIPTION
## Description

Balanced out the logos section in the About Us page, since it's a bit all over the place right now with the `space` helper.

**Before:**

![image](https://user-images.githubusercontent.com/5663877/129468229-822b9252-8cd0-412b-b257-a8885213c029.png)

**After**

![image](https://user-images.githubusercontent.com/5663877/129468232-5c9b6196-fe98-454b-8654-844bb547acdd.png)