### PR TITLE
fix(security): add CSP rules for `stats.g.doubleclick.net`

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -12,7 +12,7 @@
     X-XSS-Protection = "1; mode=block"
     X-Content-Type-Options = "nosniff"
     Referrer-Policy = "same-origin"
-    Content-Security-Policy = "default-src 'self'; connect-src 'self' analytics.google.com; style-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-inline' *.googletagmanager.com analytics.google.com; img-src 'self' blob: data: https:; frame-ancestors 'none';"
+    Content-Security-Policy = "default-src 'self'; connect-src 'self' analytics.google.com stats.g.doubleclick.net; style-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-inline' *.googletagmanager.com analytics.google.com; img-src 'self' blob: data: https:; frame-ancestors 'none';"
     Permissions-Policy = "camera=(), microphone=(), geolocation=(), interest-cohort=()"
 
 [[headers]]
@@ -22,7 +22,7 @@
     X-XSS-Protection = "1; mode=block"
     X-Content-Type-Options = "nosniff"
     Referrer-Policy = "same-origin"
-    Content-Security-Policy = "default-src 'self'; connect-src 'self' analytics.google.com; style-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-inline' *.googletagmanager.com *.netlify.com unpkg.com analytics.google.com 'unsafe-eval' media-library.cloudinary.com; frame-src 'self' cloudinary.com; img-src 'self' blob: data: https:; frame-ancestors 'none';"
+    Content-Security-Policy = "default-src 'self'; connect-src 'self' analytics.google.com stats.g.doubleclick.net; style-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-inline' *.googletagmanager.com *.netlify.com unpkg.com analytics.google.com 'unsafe-eval' media-library.cloudinary.com; frame-src 'self' cloudinary.com; img-src 'self' blob: data: https:; frame-ancestors 'none';"
     Permissions-Policy = "camera=(), microphone=(), geolocation=(), interest-cohort=()"
 
 [[headers]]

--- a/next.config.js
+++ b/next.config.js
@@ -4,7 +4,7 @@ const withBundleAnalyzer = require("@next/bundle-analyzer")({
 
 const ContentSecurityPolicy = `
   default-src 'self';
-  connect-src 'self' analytics.google.com;
+  connect-src 'self' analytics.google.com stats.g.doubleclick.net;
   script-src 'self' 'unsafe-inline' 'unsafe-eval' *.googletagmanager.com *.netlify.com unpkg.com media-library.cloudinary.com analytics.google.com *.google-analytics.com;
   style-src 'self' 'unsafe-inline';
   frame-src 'self' cloudinary.com;


### PR DESCRIPTION
## Description

Another rule that we forgot to add.

![image](https://user-images.githubusercontent.com/5663877/129469915-27d2b209-0eb4-40f2-bd45-1e246d7277e6.png)
