### PR TITLE
chore: migrate tailwind config to `tailwind-preset-wbw`

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
   "dependencies": {
     "@headlessui/react": "^1.3.0",
     "@heroicons/react": "1.0.2",
+    "@kawalcovid19/tailwind-preset-wbw": "^0.1.1",
     "@netlify/plugin-nextjs": "3.7.1",
     "@tailwindcss/forms": "^0.3.3",
     "@tailwindcss/typography": "0.4.1",

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -4,55 +4,16 @@ module.exports = {
   mode: "jit",
   purge: ["./pages/**/*.{js,ts,jsx,tsx}", "./components/**/*.{js,ts,jsx,tsx}"],
   darkMode: false, // or 'media' or 'class'
+  presets: [require("@kawalcovid19/tailwind-preset-wbw")],
   theme: {
     extend: {
-      colors: {
-        // WargaBantuWarga.com brand colour
-        brand: {
-          DEFAULT: "#1667c2",
-          50: "#c5ddf8",
-          100: "#aed0f6",
-          200: "#80b5f1",
-          300: "#539beb",
-          400: "#2580e6",
-          500: "#1667c2",
-          600: "#114f94",
-          700: "#0c3666",
-          800: "#061e39",
-          900: "#01060b",
-        },
-        "light-blue": {
-          DEFAULT: "#0ea5e9",
-          50: "#f0f9ff",
-          100: "#e0f2fe",
-          200: "#bae6fd",
-          300: "#7dd3fc",
-          400: "#38bdf8",
-          500: "#0ea5e9",
-          600: "#0284c7",
-          700: "#0369a1",
-          800: "#075985",
-          900: "#0c4a6e",
-        },
-      },
       fontFamily: {
         sans: ["Inter", ...defaultTheme.fontFamily.sans],
-      },
-      typography: {
-        DEFAULT: {
-          css: {
-            hr: {
-              borderColor: "#9ca3af",
-              marginTop: "1.5rem",
-              marginBottom: "1.5rem",
-            },
-          },
-        },
       },
     },
   },
   variants: {
     extend: {},
   },
-  plugins: [require("@tailwindcss/typography"), require("@tailwindcss/forms")],
+  plugins: [],
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -2357,6 +2357,11 @@
     "@types/yargs" "^16.0.0"
     chalk "^4.0.0"
 
+"@kawalcovid19/tailwind-preset-wbw@^0.1.1":
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/@kawalcovid19/tailwind-preset-wbw/-/tailwind-preset-wbw-0.1.1.tgz#5ba64d99e0277c432d59d9351115797a45afae73"
+  integrity sha512-97o2v2PAcUcaeOw8f11P0hjpEZzwybwAGuN79Kfe+Ct7fabko9VHpRm9eKi1dGTYVKo7j6V/TmJOjhBStDrzlw==
+
 "@mrmlnc/readdir-enhanced@^2.2.1":
   version "2.2.1"
   resolved "https://registry.yarnpkg.com/@mrmlnc/readdir-enhanced/-/readdir-enhanced-2.2.1.tgz#524af240d1a360527b730475ecfa1344aa540dde"


### PR DESCRIPTION
## Description

Migrate Tailwind CSS config to use `tailwind-preset-wbw`. Any changes to the Tailwind CSS config shall be made in the presets repo from now on:

https://github.com/kawalcovid19/tailwind-preset-wbw
