### PR TITLE
fix: changed card button colours to `brand`

### DIFF
--- a/components/kontak-darurat/emergency-contact-card.tsx
+++ b/components/kontak-darurat/emergency-contact-card.tsx
@@ -22,8 +22,8 @@ export function EmergencyContactCard(contact: ContactDetail) {
       <div className="p-3 justify-center">
         <PrimaryAnchorButton
           block
-          className="bg-light-blue-400 font-normal focus:bg-light-blue hover:bg-light-blue-600 text-white"
-          color="none"
+          className="font-normal"
+          color="brand"
           data-testid={`contact-button-${contact.name}`}
           href={contact.url}
           rel="nofollow noopener noreferrer"


### PR DESCRIPTION
## Description

Fixed the colours for the card buttons from `light-blue` to `brand` to make it consistent with the other pages' cards.

**Before**

![image](https://user-images.githubusercontent.com/5663877/129587063-0329f389-8914-4044-a172-a8eae762790d.png)

**After**

![image](https://user-images.githubusercontent.com/5663877/129587138-8b142d1c-cec2-4d9b-a093-92bacb4d4de4.png)
