### PR TITLE
Add Conditional Deployment Schedule Based on Hour

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -4,7 +4,8 @@ name: Deploy
 
 on:
   schedule:
-    - cron: "*/30 * * * *"
+    - cron: "*/30 0-17,23 * * *"
+    - cron: "*/60 18-22 * * *"
 
 jobs:
   deploy:


### PR DESCRIPTION
Closes #246

## Description

- Add additional cron schedule (github workflow able to accept multiple schedules as stated in https://github.community/t/multiple-schedules-for-workflow/154811)
- Adjust the hour as the workflow hour is UTC but ours is UTC+7
- For 18 - 22 (01.00 WIB - 05.00 WIB) it runs every 1 hour and for 0 - 17,23 (06.00 WIB - 24.00 WIB) it runs every 30 minutes (note that the cron schedule is inclusive)