### PR TITLE
chore: make kodiak use merge messages from PR title

### DIFF
--- a/.kodiak.toml
+++ b/.kodiak.toml
@@ -3,3 +3,11 @@ version = 1
 [merge.automerge_dependencies]
 versions = ["minor", "patch"]
 usernames = ["dependabot"]
+
+# https://kodiakhq.com/docs/recipes#better-merge-messages
+[merge.message]
+title = "pull_request_title"
+body = "pull_request_body"
+include_pr_number = true
+body_type = "markdown"
+strip_html_comments = true


### PR DESCRIPTION
## Description

https://kodiakhq.com/docs/recipes#better-merge-messages

> GitHub's default merge commits are ugly. GitHub uses the title of the first commit for the merge title and combines all of the other commit titles and bodies for the merge body.
>
> Using the pull request title and body give a cleaner, more useful merge commit.
>
> This config uses the PR title and body, along with the PR number to create a nice merge commit. Additionally we strip HTML comments from the PR markdown body which can be useful if your GitHub repo has PR templates.

For us, we only need the title, since we only require the PR commit message to follow conventional changelog.
