### PR TITLE
fix: minor fixes to homepage widgets

### DIFF
--- a/components/home/homepage-supported-apps.tsx
+++ b/components/home/homepage-supported-apps.tsx
@@ -55,7 +55,7 @@ export function HomepageSupportedApps() {
           Terdampak COVID-19?
         </p>
         <Link href="/telekonseling" passHref>
-          <OutlineAnchorButton color="brand" rounded size="lg">
+          <OutlineAnchorButton block color="brand" rounded size="lg">
             Lihat daftar di sini
           </OutlineAnchorButton>
         </Link>

--- a/components/home/homepage-whatsapp-cta.tsx
+++ b/components/home/homepage-whatsapp-cta.tsx
@@ -5,7 +5,7 @@ import siteConfig from "~/lib/content/site-config";
 
 export function HomePageWhatsAppCTA() {
   return (
-    <HomePageSection className="px-4 py-6 space-y-4 text-center">
+    <HomePageSection className="px-4 pt-6 pb-24 space-y-4 text-center sm:pb-6">
       <h2 className="font-semibold">Masih belum dapat info yang kamu cari?</h2>
       <PrimaryAnchorButton
         block

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -8,7 +8,7 @@ import { HomePageDonation } from "~/components/home/homepage-donation";
 import { HomepageHeader } from "~/components/home/homepage-header";
 import { HomePageLatestNews } from "~/components/home/homepage-latest-news";
 import { HomePageStart } from "~/components/home/homepage-start";
-// import { HomePageTelemedicineCTA } from "~/components/home/homepage-telemedicine-cta";
+import { HomePageTelemedicineCTA } from "~/components/home/homepage-telemedicine-cta";
 import { HomePageWelcome } from "~/components/home/homepage-welcome";
 import { HomepageSupportedApps } from "~/components/home/homepage-supported-apps";
 import { HomePageWhatsAppCTA } from "~/components/home/homepage-whatsapp-cta";
@@ -17,7 +17,6 @@ import { Container } from "~/components/ui/container";
 import { attributes } from "~/lib/content/home-page";
 import { LatestNewsItem } from "~/lib/content/informasi-terbaru";
 import siteConfig from "~/lib/content/site-config";
-import { HomePageTelemedicineCTA } from "~/components/home/homepage-telemedicine-cta";
 import { JsonLdWebsite } from "~/components/json-ld/website";
 
 const meta = {


### PR DESCRIPTION
## Description

### One.

Fixes the CTA button for the counseling widget to have `block` variant.

### Two.

Adds extra bottom padding on the WhatsApp widget to make space for the scroll to top button.

![image](https://user-images.githubusercontent.com/5663877/131658348-e2a1b348-2bc2-4780-9ca9-0dd8686f63cf.png)

