### PR TITLE
chore: revert fetching data every Netlify export

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "lint": "eslint \"**/*.{js,jsx,ts,tsx,yml,yaml}\"",
     "lint:fix": "eslint --fix \"**/*.{js,jsx,ts,tsx,yml,yaml}\"",
     "mirror-box": "ts-node etc/mirror-box.ts",
-    "netlify-export": "yarn fetch-wbw && yarn build && next export",
+    "netlify-export": "yarn mirror-box && yarn build && next export",
     "prepare": "husky install",
     "start": "next start",
     "cypress:open": "cypress open",


### PR DESCRIPTION
## Description

Revert a7532dd of https://github.com/Nefoplayground/wargabantuwarga.com

That commit was supposedly used only for debugging purposes,
but it was unintentionally merged in #806.

Also see https://github.com/kawalcovid19/wargabantuwarga.com/pull/806#issuecomment-942403579, it's why the commit existed in the first place.

## Current Tasks

Nothing, but #804 might be required to be merged before this PR? Though, this hasn't been used anywhere else, so it won't really hurt. 🙂