### PR TITLE
fix: migrate website URLs from .com to .id domain

### DIFF
--- a/.github/workflows/lighthouse-ci-prod.yml
+++ b/.github/workflows/lighthouse-ci-prod.yml
@@ -26,7 +26,7 @@ jobs:
           yarn global add @lhci/cli@0.8.x
           echo -e "\n"
           echo "Start collecting LH report..."
-          lhci collect --url=https://www.wargabantuwarga.com/ --url=https://www.wargabantuwarga.com/tentang-kami --url=https://www.wargabantuwarga.com/donasi --url=https://www.wargabantuwarga.com/faq --url=https://www.wargabantuwarga.com/provinces -n=5
+          lhci collect --url=https://www.wargabantuwarga.id/ --url=https://www.wargabantuwarga.id/tentang-kami --url=https://www.wargabantuwarga.id/donasi --url=https://www.wargabantuwarga.id/faq --url=https://www.wargabantuwarga.id/provinces -n=5
           echo -e "\n"
           echo "Start asserting LH score..."
           lhci assert --config=./lighthouserc.js

--- a/_content/site-config.json
+++ b/_content/site-config.json
@@ -2,6 +2,6 @@
   "site_name": "Warga Bantu Warga",
   "site_tagline": "Informasi Faskes & Alkes untuk COVID-19",
   "site_description": "#WargaBantuWarga adalah situs yang memuat informasi seputar COVID-19 dan kontak fasilitas/alat kesehatan di seluruh Indonesia yang dikumpulkan relawan melalui pencarian di internet atau media sosial.",
-  "site_url": "https://www.wargabantuwarga.com",
+  "site_url": "https://www.wargabantuwarga.id",
   "whatsapp_contact_url": "https://bit.ly/hotlinewarga"
 }

--- a/components/__tests__/links-well.test.tsx
+++ b/components/__tests__/links-well.test.tsx
@@ -73,7 +73,7 @@ describe("LinksWell", () => {
         links={[
           { href: "/faq", text: "Info Umum A" },
           {
-            href: "https://www.wargabantuwarga.com/faq",
+            href: "https://www.wargabantuwarga.id/faq",
             text: "Info Umum B",
             internal: true,
           },
@@ -94,10 +94,7 @@ describe("LinksWell", () => {
       name: "Info Umum B",
     });
 
-    expect(linkB).toHaveAttribute(
-      "href",
-      "https://www.wargabantuwarga.com/faq",
-    );
+    expect(linkB).toHaveAttribute("href", "https://www.wargabantuwarga.id/faq");
     expect(linkB).not.toHaveAttribute("target");
     expect(linkB).not.toHaveAttribute("rel");
   });

--- a/components/home/homepage-start.tsx
+++ b/components/home/homepage-start.tsx
@@ -1,13 +1,10 @@
 import React from "react";
 
-import Image from "next/image";
 import Link from "next/link";
 import { PrimaryAnchorButton } from "../ui/button";
 import { HomePageSection } from "./homepage-section";
 import { HomePageMenu } from "./homepage-menu";
 import { HomePageEmergencyContactCTA } from "./homepage-emergency-cta";
-import { HOMEPAGE_START_CTA_URL } from "~/constants";
-import { cloudinaryLoader } from "~/lib/image/cloudinary-loader";
 
 export function HomePageStart() {
   return (
@@ -34,24 +31,6 @@ export function HomePageStart() {
       </div>
       <div className="px-4 py-6">
         <HomePageMenu />
-      </div>
-      <div className="px-4 py-6">
-        <a
-          href={HOMEPAGE_START_CTA_URL}
-          rel="nofollow noopener noreferrer"
-          target="_blank"
-        >
-          <Image
-            alt="Ajukan bantuan sembako jika positif Covid-19 - Daftar Sekarang"
-            height={236}
-            layout="responsive"
-            loader={cloudinaryLoader}
-            loading="lazy"
-            quality={90}
-            src="v1627319803/sembako-cta-v2_czojls.png"
-            width={656}
-          />
-        </a>
       </div>
     </HomePageSection>
   );

--- a/constants/index.ts
+++ b/constants/index.ts
@@ -1,2 +1,1 @@
-export const PUBLIC_PATH = "https://www.wargabantuwarga.com";
-export const HOMEPAGE_START_CTA_URL = "https://sembako.wargabantuwarga.com";
+export const PUBLIC_PATH = "https://www.wargabantuwarga.id";

--- a/lib/__tests__/jsonld-generator.test.ts
+++ b/lib/__tests__/jsonld-generator.test.ts
@@ -11,18 +11,18 @@ describe("jsonLdGenerator", () => {
     ];
     const result = makeBreadcrumbJsonLd(param);
     const expectedResult = {
-      "@id": "https://www.wargabantuwarga.com/provinces/#breadcrumb",
+      "@id": "https://www.wargabantuwarga.id/provinces/#breadcrumb",
       "@type": "BreadcrumbList",
       itemListElement: [
         {
           "@type": "ListItem",
-          item: "https://www.wargabantuwarga.com/",
+          item: "https://www.wargabantuwarga.id/",
           name: "Home",
           position: 1,
         },
         {
           "@type": "ListItem",
-          item: "https://www.wargabantuwarga.com/provinces",
+          item: "https://www.wargabantuwarga.id/provinces",
           name: "Province",
           position: 2,
         },

--- a/lib/__tests__/string-utils.test.ts
+++ b/lib/__tests__/string-utils.test.ts
@@ -100,19 +100,19 @@ describe("isInternalLink", () => {
   it.each`
     input                                                                     | expected
     ${"/faq"}                                                                 | ${true}
-    ${"wargabantuwarga.com"}                                                  | ${true}
-    ${"wargabantuwarga.com/faq"}                                              | ${true}
-    ${"www.wargabantuwarga.com"}                                              | ${true}
-    ${"www.wargabantuwarga.com/faq"}                                          | ${true}
-    ${"http://wargabantuwarga.com"}                                           | ${true}
-    ${"http://wargabantuwarga.com/faq"}                                       | ${true}
-    ${"http://www.wargabantuwarga.com"}                                       | ${true}
-    ${"http://www.wargabantuwarga.com/faq"}                                   | ${true}
-    ${"https://www.wargabantuwarga.com"}                                      | ${true}
-    ${"https://www.wargabantuwarga.com/"}                                     | ${true}
-    ${"https://www.wargabantuwarga.com/provinces"}                            | ${true}
-    ${"https://hotline.wargabantuwarga.com"}                                  | ${false}
-    ${"https://hotline-wargabantuwarga.com"}                                  | ${false}
+    ${"wargabantuwarga.id"}                                                   | ${true}
+    ${"wargabantuwarga.id/faq"}                                               | ${true}
+    ${"www.wargabantuwarga.id"}                                               | ${true}
+    ${"www.wargabantuwarga.id/faq"}                                           | ${true}
+    ${"http://wargabantuwarga.id"}                                            | ${true}
+    ${"http://wargabantuwarga.id/faq"}                                        | ${true}
+    ${"http://www.wargabantuwarga.id"}                                        | ${true}
+    ${"http://www.wargabantuwarga.id/faq"}                                    | ${true}
+    ${"https://www.wargabantuwarga.id"}                                       | ${true}
+    ${"https://www.wargabantuwarga.id/"}                                      | ${true}
+    ${"https://www.wargabantuwarga.id/provinces"}                             | ${true}
+    ${"https://hotline.wargabantuwarga.id"}                                   | ${false}
+    ${"https://hotline-wargabantuwarga.id"}                                   | ${false}
     ${"https://kawalcovid19.id/content/1931/cara-isolasi-mandiri-yang-benar"} | ${false}
     ${"https://bit.ly/hotlinewarga"}                                          | ${false}
   `(

--- a/lib/content/__mocks__/site-config.ts
+++ b/lib/content/__mocks__/site-config.ts
@@ -5,7 +5,7 @@ const config: SiteConfig = {
   site_tagline: "Informasi Faskes & Alkes untuk COVID-19",
   site_description:
     "#WargaBantuWarga adalah situs yang memuat informasi seputar COVID-19 dan kontak fasilitas/alat kesehatan di seluruh Indonesia yang dikumpulkan relawan melalui pencarian di internet atau media sosial.",
-  site_url: "https://www.wargabantuwarga.com",
+  site_url: "https://www.wargabantuwarga.id",
   whatsapp_contact_url: "https://bit.ly/hotlinewarga",
 };
 

--- a/lib/string-utils.ts
+++ b/lib/string-utils.ts
@@ -141,8 +141,8 @@ export function isInternalLink(link: string): boolean {
     .split("/")[0];
   return (
     link.startsWith("/") ||
-    domain === "www.wargabantuwarga.com" ||
-    domain === "wargabantuwarga.com"
+    domain === "www.wargabantuwarga.id" ||
+    domain === "wargabantuwarga.id"
   );
 }
 

--- a/next-sitemap.js
+++ b/next-sitemap.js
@@ -1,5 +1,5 @@
 module.exports = {
-  siteUrl: "https://www.wargabantuwarga.com",
+  siteUrl: "https://www.wargabantuwarga.id",
   generateRobotsTxt: true,
   sitemapSize: 1000,
   exclude: ["/provinces/tentang-database-0"],

--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -61,7 +61,7 @@ export default function App({ Component, pageProps, router }: AppProps) {
           site_name: meta.siteName,
           images: [
             {
-              url: "https://wargabantuwarga.com/wbw_og.png",
+              url: "https://wargabantuwarga.id/wbw_og.png",
               alt: meta.siteName,
               height: 640,
               width: 1427,

--- a/public/.well-known/security.txt
+++ b/public/.well-known/security.txt
@@ -3,7 +3,7 @@ Hash: SHA512
 
 Contact: mailto:admin@kawalcovid19.id
 Expires: 2022-08-10T16:59:00.000Z
-Canonical: https://www.wargabantuwarga.com/.well-known/security.txt
+Canonical: https://www.wargabantuwarga.id/.well-known/security.txt
 -----BEGIN PGP SIGNATURE-----
 
 iQIzBAEBCgAdFiEE0UPXQYU1D+eqKfsbDIqvr550G/UFAmEXCfcACgkQDIqvr550

--- a/public/admin/config.yml
+++ b/public/admin/config.yml
@@ -4,7 +4,7 @@ backend:
 media_folder: public/images
 public_folder: /images
 publish_mode: editorial_workflow
-display_url: https://www.wargabantuwarga.com
+display_url: https://www.wargabantuwarga.id
 media_library:
   name: cloudinary
   config:


### PR DESCRIPTION
## Description

Migrate all website URLs from `wargabantuwarga.com` to `wargabantuwarga.id` domain while keeping GitHub repository references unchanged.

### Changes Made

**Core Configuration:**
- `constants/index.ts` - Changed `PUBLIC_PATH` to `.id`, removed `HOMEPAGE_START_CTA_URL`
- `next-sitemap.js` - Changed siteUrl to `.id`
- `_content/site-config.json` - Changed site_url to `.id`
- `public/admin/config.yml` - Changed display_url to `.id`
- `public/.well-known/security.txt` - Changed canonical URL to `.id`

**Application Code:**
- `pages/_app.tsx` - Changed OG image URL to `.id`
- `lib/string-utils.ts` - Updated domain validation to check `.id`
- `components/home/homepage-start.tsx` - Removed sembako CTA section (subdomain no longer in use)

**CI/CD:**
- `.github/workflows/lighthouse-ci-prod.yml` - Changed Lighthouse test URLs to `.id`

**Tests:**
- Updated all test files with new `.id` domain URLs

## Current Tasks

- [x] Update core configuration files
- [x] Update application code with new domain
- [x] Update CI/CD workflows
- [x] Update test files
- [x] Remove sembako subdomain reference
- [x] Verify tests pass